### PR TITLE
Update LoadoutScript.lua

### DIFF
--- a/CoreScripts/BackpackScripts/LoadoutScript.lua
+++ b/CoreScripts/BackpackScripts/LoadoutScript.lua
@@ -602,12 +602,12 @@ local addingPlayerChild = function(child, equipped, addToSlot, inventoryGearButt
 	
 	gearClone.MouseEnter:connect(function()
 		local Tool = gearClone.GearReference and gearClone.GearReference.Value
-		if Tool and Tool:IsA("Tool") and Tool.ToolTip ~= "" then
+		if type(Tool) == 'userdata' and Tool:IsA("Tool") and Tool.ToolTip ~= "" then
 			showToolTip(gearClone, Tool.ToolTip)
 		end
 	end)
 	
-	gearClone.MouseLeave:connect(function(
+	gearClone.MouseLeave:connect(function()
 		hideToolTip(gearClone)
 	end)
 


### PR DESCRIPTION
- Fix for 'ToolTip is not a valid member of HopperBin' error

Note: I can't accurately test it as I cannot change corescripts in studio to debug, and this script uses protected methods, but if my logic is correct this should work now?
