### PR TITLE
[Bugfix] HealthScript - Healthbar filling almost whole screen

### DIFF
--- a/CoreScripts/HealthScript.lua
+++ b/CoreScripts/HealthScript.lua
@@ -117,6 +117,7 @@ function UpdateGui(health)
 		
 	local width = (health / currentHumanoid.MaxHealth)
  	width = math.max(math.min(width,1),0) -- make sure width is between 0 and 1
+ 	if width ~= width then width = 0 end -- so called "god" modes result in 1.#IND so now that's solved
 		
 	local healthDelta = lastHealth - health
 	lastHealth = health


### PR DESCRIPTION
Bug fixed where red healthbar takes over half of your screen due so called "godmode".
(Due maxhealth being 0 or math.huge, both making width result in negative infinity)
With this fix whenever this happens, it'll just act as if on full health.
