### PR TITLE
[LagFix] Some other stuff & lag fix

### DIFF
--- a/CoreScripts/Settings.lua
+++ b/CoreScripts/Settings.lua
@@ -686,7 +686,7 @@ function initializeDevConsole()
 		Dev_Container.Position = UDim2.new(0, pPos.X + delta.X, 0, pPos.Y + delta.Y)
 	end
 
-	local titleBarDown,titleBarDouble = 0,false
+	local titleBarDown,titleBarCount,titleBarBusy = 0,0,false
 	Dev_TitleBar.TextButton.MouseButton1Down:connect(function(x, y)
 		previousMousePos = Vector2.new(x, y) titleBarDown = tick()
 		pPos = Dev_Container.AbsolutePosition
@@ -694,11 +694,21 @@ function initializeDevConsole()
 
 	Dev_TitleBar.TextButton.MouseButton1Up:connect(function(x, y)
 		clean() if tick() - titleBarDown > 0.25 then return end
-		-- Fast double click on titlebar (same as used for moving) will put the console in default size/position
-		if titleBarDouble then Enum.EasingDirection:lol(Enum.EasingDirection.Out)
-			local s,p = UDim2.new(0.5, 20, 0.5, 20),UDim2.new(0, 100, 0, 10)
-			Dev_Container:TweenSizeAndPosition(s, p, Enum.EasingDirection.Out, Enum.EasingStyle.Sine, 1, true)
-		end titleBarDouble = not titleBarDouble
+		titleBarCount = titleBarCount + 1
+		if not titleBarBusy then
+			titleBarBusy = true
+			local count = titleBarCount
+			Delay(0.25,function()
+				while count ~= titleBarCount do
+					count = titleBarCount wait(0.25)
+				end titleBarBusy = false
+				titleBarCount = 0
+				if count == 2 then
+					local s,p = UDim2.new(0.5, 20, 0.5, 20),UDim2.new(0, 100, 0, 10)
+					Dev_Container:TweenSizeAndPosition(s, p, Enum.EasingDirection.Out, Enum.EasingStyle.Sine, 1, true)
+				end
+			end)
+		end
 	end)
 
 	---Handle Dev-Console Size
@@ -1029,7 +1039,9 @@ function initializeDevConsole()
 	-- Easy, fast, and working nicely
 	local function numberWithZero(num)
 		return (num < 10 and "0" or "")..num
-	end local str = "%s:%s:%s"
+	end
+	-- Standard format of time used here
+	local str = "%s:%s:%s"
 	function ConvertTimeStamp(timeStamp)
 		local localTime = timeStamp - os.time() + math.floor(tick())
 		local dayTime = localTime % 86400
@@ -1420,7 +1432,8 @@ local function createHelpDialog(baseZIndex)
 	
 		devConsoleButton.MouseButton1Click:connect(function()
 			toggleDeveloperConsole()
-			resumeGameFunction(shield)
+ 			shield.Visible = false
+ 			game.GuiService:RemoveCenterDialog(shield)
 		end)
 	end
 	


### PR DESCRIPTION
- Made some stuff more efficient (20x waitForChild() for one object isn't really efficient...)
  (even if it's now doing the same, but in one much cleaner function)
- Added a refreshQueue to the developer console, limiting refreshTextHolder()
  It now refreshes the holder every 0.1s if needed to, limiting a lot of lag,
  especially when serverlog is getting requested for creator or the local one is getting loaded.
  (The old) refreshTextHolder() (now refreshTextHolderForReal) is one of the most intensive
  functions of the console, "rendering" the whole console with all messages.
  Whenever there is output getting spammed for some reason, it would refresh
  the list for every message, creating a lot of lag, surely for slow computers.
  Now when for example 50x something gets added to the output in one tick, it'll queue
  the refreshTextHolder() so it'll fire after 0.1s, thuss once for 50+ output messages.
  With the old system it would have refreshed the holder 50x time in one single tick (=> lagg)
- devConsoleButton.MouseButton1Click has been edited that whenever you press the Log-button in
  the Help section of the menu, it'll resume the game, aka hide the menu.
  Currently whenever you press the button, it exists the help section to the main menu.
- Doubleclicking the titleBar of the devConsole (same used to move it) will
  tween the console to it's default position and size

(Small note: ConvertTimeStamp's local variable 'str' is outside, as it is a constant now
