### PR TITLE
Updated startGui()

### DIFF
--- a/CoreScripts/HealthScript.lua
+++ b/CoreScripts/HealthScript.lua
@@ -183,7 +183,7 @@ end
 function startGui()
 	local character = Game.Players.LocalPlayer.Character
 
-	while (character == nil) do
+	while (character == nil) or (character.Parent == nil) do
 		character = Game.Players.LocalPlayer.Character
 		wait(1/30)
 	end


### PR DESCRIPTION
startGui() will wait until the character's parent is not equal to nil, so that character:WaitForChild() can be called with no error.
