### PR TITLE
Fixed issue #15

### DIFF
--- a/CoreScripts/HealthScript.lua
+++ b/CoreScripts/HealthScript.lua
@@ -165,9 +165,10 @@ function humanoidDied()
 end
 
 function disconnectPlayerConnections()
+	characterAddedConnection:disconnect()
+	if not humanoidDiedConnection then return end
 	humanoidDiedConnection:disconnect()
 	healthChangedConnection:disconnect()
-	characterAddedConnection:disconnect()
 end
 
 function newPlayerCharacter()
@@ -183,18 +184,18 @@ function startGui()
 		wait(1/30)
 	end
 
-	currentHumanoid = character:WaitForChild("Humanoid")
+	currentHumanoid = character:findFirstChild("Humanoid")
 	if not Game.StarterGui:GetCoreGuiEnabled(Enum.CoreGuiType.Health) then
 		return
 	end
 
 	if currentHumanoid then
-		CreateGui()
 		healthChangedConnection = currentHumanoid.HealthChanged:connect(UpdateGui)
 		humanoidDiedConnection = currentHumanoid.Died:connect(humanoidDied)
+		UpdateGui(currentHumanoid.Health)
 	end
-
-	UpdateGui(currentHumanoid.Health)
+		
+	CreateGui()
 
 	characterAddedConnection = Game.Players.LocalPlayer.CharacterAdded:connect(newPlayerCharacter)
 end


### PR DESCRIPTION
https://github.com/ROBLOX/Core-Scripts/issues/15: "attempt to index upvalue 'humanoidDiedConnection' (a nil value)"

Whenever SetCoreGuiEnabled("Health",false) is called while it is already disabled, it'll
try to disconnect all events.
When there never was a humanoid yet, this leads to events not being connected yet.

Changed the way startGui() starts, as it could yield forever in some cases.
Now it'll just check, "is there a Humanoid?", and handle what's needed.

healthChangedConnection and humanoidDiedConnection only get disconnected once they're set.
(Checking if humanoidDiedConnection isn't nil, as they get set at the same time)
