### PR TITLE
Due issue #27 (Tiny backpack due resizing screen)

### DIFF
--- a/CoreScripts/BackpackScripts/BackpackBuilder.lua
+++ b/CoreScripts/BackpackScripts/BackpackBuilder.lua
@@ -22,7 +22,7 @@ local function IsTouchDevice()
 end 
 
 local function IsPhone()
-	if game:GetService("GuiService"):GetScreenResolution().Y <= 320 then 	 	
+	if game:GetService("GuiService"):GetScreenResolution().Y <= 500 then 	 	
 		return true	 	
 	end 	 	
 	return false 	 	


### PR DESCRIPTION
As solution for issue https://github.com/ROBLOX/Core-Scripts/issues/27 opened by matthewdean.

As the GetScreenResolution() returns the real screen's resolution, and not just
the resolution of the roblox player, this will work to check if it's a phone.
(Unless someone uses a resolution on pc with a height of 320 or less, if that's possible)
