### PR TITLE
Updated StringTrim

### DIFF
--- a/CoreScripts/ChatScript.lua
+++ b/CoreScripts/ChatScript.lua
@@ -31,12 +31,12 @@ end
 -- Users can use enough white spaces to spoof chatting as other players
 -- This function removes trailing and leading white spaces
 -- AFAIK, there is no reason for spam white spaces 
-local function StringTrim(str)
+local function StringTrim(str,nstr)
 	-- %s+ stands whitespaces
 	-- We yank out any whitespaces at the begin and end of the string
 	-- After that, we put a tab behind newlines
 	-- That way people can't fake messages on a new line
-	return str:match("^%s*(.-)%s*$"):gsub("\n","\n\t")
+	return str:match("^%s*(.-)%s*$"):gsub("\n","\n"..nstr)
 end 
 
 while Game.Players.LocalPlayer == nil do wait(0.03) end
@@ -692,10 +692,8 @@ function Chat:CreateMessage(cPlayer, message)
 		pName = ''
 	else 
 		pName = cPlayer.Name			
-	end 	
-	message = StringTrim(message)		
-	local pLabel
-	local mLabel 
+	end	
+	local pLabel,mLabel 
 	-- Our history stores upto 50 messages that is 100 textlabels 
 	-- If we ever hit the mark, which would be in every popular game btw 
 	-- we wrap around and reuse the labels 
@@ -768,7 +766,9 @@ function Chat:CreateMessage(cPlayer, message)
 			nString = Chat:ComputeSpaceString(pLabel)
 		else 
 			nString = self.CachedSpaceStrings_List[pName]
-		end 		
+		end
+		
+		message = StringTrim(message,nString)
 
 		mLabel = Gui.Create'TextLabel' 
 						{


### PR DESCRIPTION
As (partially) requested by devDiggy/Digpoe, just not completely as he wanted.
It keeps its old function, but now also puts spaces afer newlines.
(number of spaces based on nString, thuss making the message appear after ':' on the previous line)
That way, people can't fake messages by using newlines:

```
> "Hello world!\nTelamon: I'm here, people!"
einsteinK: Hello world!
Telamon: I'm here, people!
```

Now that would result into this message with a in it:

```
einsteinK: Hello world!
           Telamon: I'm here, people!
```
