### PR TITLE
Sort players alphabeticly

### DIFF
--- a/CoreScripts/PlayerListScript.lua
+++ b/CoreScripts/PlayerListScript.lua
@@ -1383,7 +1383,7 @@ end
 function PlayerSortFunction(a,b)
  -- prevents flipping out leaderboard
 	if a['Score'] == b['Score'] then
-		return a['Player'].Name:upper() < b['Player'].Name:upper()
+		return a['Player'].Name:upper() > b['Player'].Name:upper()
 	end
 	if not a['Score'] then return false end
 	if not b['Score'] then return true end


### PR DESCRIPTION
Makes the playerlist sort from A to Z, instead of Z to A as before.
(Most players prefer real alphabeticly, as Z-A looks weird)
