### PR TITLE
Fixing bug free items + Grammar mistake

### DIFF
--- a/CoreScripts/PurchasePromptScript.lua
+++ b/CoreScripts/PurchasePromptScript.lua
@@ -731,6 +731,12 @@ function canPurchaseItem()
 			return true, nil, nil, true, descText 
 		end
 	end
+	
+	-- For public models, as there is still the freeButton, indicating it should be
+	-- available, while this function (canPurchaseItem) doesn't count on free stuff
+	if isFreeItem() then
+		return true	
+	end
 
 	purchaseDialog.BodyFrame.AfterBalanceText.Visible = true 
 
@@ -752,7 +758,7 @@ function canPurchaseItem()
 
 	-- now we start talking money, making sure we are going to be able to purchase this
 	if not setCurrencyAmountAndType(tonumber(currentProductInfo["PriceInRobux"]), tonumber(currentProductInfo["PriceInTickets"])) then
-		descText = "We could retrieve the price of the item correctly. Please try again later." 
+		descText = "We couldn't retrieve the price of the item correctly. Please try again later." 
 		return true, nil, nil, true, descText
 	end	
 


### PR DESCRIPTION
"We could retrieve the price ..." should've been "We couldn't retrieve the price ..."
Also, this shound support free stuff, and up until some time ago, it actually did.
All code was still written to do this, except that canPurchaseItem() didn't count on free stuff.
Now whenever it's a free (takeable) item the player doesn't own yet, it'll also allow it.
