### PR TITLE
Fixing isFreeItem() due API mistake

### DIFF
--- a/CoreScripts/PurchasePromptScript.lua
+++ b/CoreScripts/PurchasePromptScript.lua
@@ -660,8 +660,10 @@ function updateAfterBalanceText(playerBalance, notRightBc, balancePreText)
 end
 
 function isFreeItem()
-	-- if both of these are true, then the item is free, just prompt user if they want to take one
-	return currentProductInfo and currentProductInfo["IsForSale"] == true and currentProductInfo["IsPublicDomain"] == true
+	-- Apparently free items have 'IsForSale' set to false, but 'IsPublicDomain' set to true
+	-- Example: https://api.roblox.com/marketplace/productinfo?assetid=163811695
+	-- I've tested it, if you take it off the public domain, 'IsPublicDomain' is of course false
+	return currentProductInfo and currentProductInfo["IsPublicDomain"] == true
 end
 ---------------------------------------------- End Currency Functions ---------------------------------------------
 


### PR DESCRIPTION
The first time I fixed the buying of free items, it was purely a case of calling
the wrong functions at the wrong time.
Now it seems that 'isFreeItem()' was wrong, maybe wrong made in the first place, maybe due an API change.
Apparently if something is free, 'IsPublicDomain' is true, but 'IsForSale' stays false.
