### PR TITLE
Update RbxGui.lua

### DIFF
--- a/Libraries/RbxGui.lua
+++ b/Libraries/RbxGui.lua
@@ -3041,7 +3041,9 @@ t.CreateSetPanel = function(userIdsForSets, objectSelected, dialogClosed, size, 
 			if newImageUrl ~= insertFrame.Button.ButtonImage.Image then
 				delay(0,function()
 					game:GetService("ContentProvider"):Preload(SmallThumbnailUrl  .. assetId)
-					insertFrame.Button.ButtonImage.Image = SmallThumbnailUrl  .. assetId
+					if insertFrame:findFirstChild("Button") then
+						insertFrame.Button.ButtonImage.Image = SmallThumbnailUrl  .. assetId
+					end
 				end)
 			end
 			table.insert(insertButtonCons,


### PR DESCRIPTION
Added a check for insertFrame.Button in the setInsertButtonImageBehavior function. In some weird cases, the button is occasionally absent and causes the output to be flooded with "Button is not a valid member of Frame"
This can be replicated in the Stamper Tool plugin if you rapidly try to change sets.
