### PR TITLE
[Add-on] Empty commandbar unfocuses it

### DIFF
--- a/CoreScripts/DeveloperConsole.lua
+++ b/CoreScripts/DeveloperConsole.lua
@@ -398,8 +398,8 @@ function initializeDeveloperConsole()
 	}
 	
 	Dev_CommandBarTextBox.FocusLost:connect(function(enterPressed)
-		if enterPressed then
-			local code = Dev_CommandBarTextBox.Text
+		local code = Dev_CommandBarTextBox.Text
+		if enterPressed and code ~= "" then
 			game:GetService("LogService"):ExecuteScript(code)
 			Dev_CommandBarTextBox.Text = ""
 			


### PR DESCRIPTION
If the creator presses enter without entering text, it'll be ignored, and the commandbar won't be refocused.
This is useful for as some people want to write 1 line of code, and then leave the commandbar.
With the current system they need to press ESC or click somewhere else.
With the new system they just press enter twice when running the code.

(More of an utility improvement than anything else)
