### PR TITLE
Fix due issue 25

### DIFF
--- a/CoreScripts/PlayerListScript.lua
+++ b/CoreScripts/PlayerListScript.lua
@@ -2398,7 +2398,7 @@ function InsertPlayerFrame(nplayer)
 	nplayer.ChildAdded:connect(function(nchild) 
 		if nchild.Name == 'leaderstats' then
 			while AddingFrameLock do debugprint('in adding leaderstats lock') wait(1/30) end
-			if not nplayer:findFirstChild("leaderstats") then return end
+			if not nplayer:FindFirstChild("leaderstats") then return end
 			AddingFrameLock = true
 			LeaderstatsAdded(nentry)
 			AddingFrameLock = false


### PR DESCRIPTION
While waiting due AddingFrameLock, the leaderstats-object can be removed.
With this quick check, LeaderstatsAdded will only be called when we're sure the player still has them.

Reference: #25
