### PR TITLE
Fixing lag issue

### DIFF
--- a/CoreScripts/ChatScript.lua
+++ b/CoreScripts/ChatScript.lua
@@ -569,7 +569,7 @@ function Chat:UpdateQueue(field, diff)
 								if label:IsA('TextLabel') or label:IsA('TextButton') then
 									Spawn(function()					
 										wait(0.05)							
-										while label.TextTransparency > 0.1 do 
+										while label.TextTransparency > 0 do 
 											label.TextTransparency = label.TextTransparency - 0.2
 											wait(0.03) 
 										end 	
@@ -582,7 +582,7 @@ function Chat:UpdateQueue(field, diff)
 								else 
 									Spawn(function()					
 										wait(0.05)							
-										while label.ImageTransparency > 0.1 do 
+										while label.ImageTransparency > 0 do 
 											label.ImageTransparency = label.ImageTransparency - 0.2
 											wait(0.03) 
 										end 	


### PR DESCRIPTION
Someone mentioned lag due chatscript:
http://developer.roblox.com/forum/updates/8391-new-core-guis?start=120#91762

I found where it comes from, and fixed it.
The reason I use "> 0.1" is for rounding errors, and the fact we're substracting by 0.2, so the result will always be 0.
