### PR TITLE
stop chat frame leaving space for the settings button on PC

### DIFF
--- a/CoreScripts/ChatScript.lua
+++ b/CoreScripts/ChatScript.lua
@@ -1080,7 +1080,7 @@ function Chat:CreateGui()
 					Name = 'ChatFrame';
 					--Size = self.Configuration.Size;
 					Size = UDim2.new(0, 500, 0, 120);
-					Position = UDim2.new(0, 0, 0, 0);
+					Position = UDim2.new(0, 0, 0, 5);
 					BackgroundTransparency = 1.0;
 					--ClipsDescendants = true;
 					ZIndex = 0.0;


### PR DESCRIPTION
Since the settings button is back in the bottom left on PC, there's no sense wasting space with the chat frame being lower down to leave space for it.

As discussed on RbxDev: http://developer.roblox.com/forum/client-features/8501-what-s-with-the-pointless-waste-of-space-on-the-new-chat-coregui

I was, sadly, unable to test this in between #54 and studio not having chat. Feel free to modify position as required.
