### PR TITLE
Fixed "stuck" ChatKey

### DIFF
--- a/CoreScripts/ChatScript.lua
+++ b/CoreScripts/ChatScript.lua
@@ -929,11 +929,13 @@ function Chat:CoreGuiChanged(coreGuiType,enabled)
 		if self.TapToChatLabel then self.TapToChatLabel.Visible = enabled end 
 
 		if not Chat:IsTouchDevice() and self.ChatBar then 
-			self.ChatBar.Visible = enabled 
+			self.ChatBar.Visible = enabled
 			if enabled then
 				GuiService:SetGlobalGuiInset(0, 0, 0, 20)
+				GuiService:AddSpecialKey(Enum.SpecialKey.ChatHotkey)
 			else
 				GuiService:SetGlobalGuiInset(0, 0, 0, 0)
+				GuiService:RemoveSpecialKey(Enum.SpecialKey.ChatHotkey)
 			end
 		end
 	end


### PR DESCRIPTION
Fixed a problem, that has been fixed before, but got undone for some reason.
The problem is, that when SetCoreGuiEnabled("Chat",false) is called, the ChatKey is still bound.
This results in focusing on the chatbar, even when the chatbar isn't even visible.

This'll just add/remove the key, depending if it's needed or not.
