### PR TITLE
Fixing Purchase Free Items

### DIFF
--- a/CoreScripts/PurchasePromptScript.lua
+++ b/CoreScripts/PurchasePromptScript.lua
@@ -422,7 +422,7 @@ function doAcceptPurchase(currencyPreferredByUser)
 	else
 		url = getSecureApiBaseUrl() .. "marketplace/purchase?productId=" .. tostring(currentProductId) .. 
 			"&currencyTypeId=" .. tostring(currencyEnumToInt(currentCurrencyType)) .. 
-			"&purchasePrice=" .. tostring(currentCurrencyAmount) ..
+			"&purchasePrice=" .. tostring(currentCurrencyAmount or 0) ..
 			"&locationType=Game" .. "&locationId=" .. Game.PlaceId
 	end
 


### PR DESCRIPTION
Currently the only thing that goes wrong is, when pressing the purchase-button, it waits a second and displays:
"Roblox is currently in maintenance blablabla"     Fiddler shows an 'Internal Server Error'
Apparently, the HttpRequest fails internally when the 'purchasePrice'-paramter is "nil", as was the case for free items.
With this fix, it'll set the parameter to '0', which is accepted.
(Tested with Fiddler, spoofed the purchase request from the client)

This should be the last time we need to change something to fix the purchase of Free Items.