### PR TITLE
Fixing Part 1 of issue 84

### DIFF
--- a/CoreScripts/ChatScript2.lua
+++ b/CoreScripts/ChatScript2.lua
@@ -1058,7 +1058,7 @@ local function CreateChatBarWidget(settings)
 				this:SetChatBarText("")
 			end
 		end
-		if self.ClickToChatButton then
+		if self.ClickToChatButton and this:GetChatBarText() ~= "" then
 			self.ClickToChatButton.Visible = true
 		end
 		if this.ChatModeText then


### PR DESCRIPTION
As reported in the first half of #84

This should stop the "To chat click here"-message from appearing while there's still text inside the chatbar.
(When the bar lost focus due pressing enter, it'll be set to "", so it not being empty means the user just clicked outside the bar or so)
