### PR TITLE
[Idea] Disable CommandBar in API-generated places

### DIFF
--- a/CoreScriptsRoot/CoreScripts/DeveloperConsole.lua
+++ b/CoreScriptsRoot/CoreScripts/DeveloperConsole.lua
@@ -306,8 +306,23 @@ function initializeDeveloperConsole()
 	}
 	
 	local flagExists, flagValue = pcall(function () return settings():GetFFlag("ConsoleCodeExecutionEnabled") end)
-	local codeExecutionEnabled = flagExists and flagValue
+	local shouldEnableExecution,codeExecutionEnabled = flagExists and flagValue
+	
 	local isCreator = game:GetService("Players").LocalPlayer.userId == game.CreatorId
+	
+	-- Check if this is place is not created by CreatePlace(InPlayerInventory)Async
+	local places = game:GetService("AssetService"):GetGamePlacesAsync()
+	while shouldEnableExecution do
+		for _,place in pairs(places:GetCurrentPage()) do
+			if place.PlaceId == game.PlaceId then
+				codeExecutionEnabled = true	
+			end
+		end
+		if places.IsFinished or codeExecutionEnabled then
+			break
+		end places:AdvanceToNextPageAsync()
+	end
+	
 	local function shouldShowCommandBar()
 		return codeExecutionEnabled and isCreator
 	end


### PR DESCRIPTION
With this contraption, the commandbar shall not appear if the place is created using the CreatePlace API.
(Which means, CreatePlaceAsync and CreatePlaceInPlayerInventoryAsync)

While the commandbar won't be visible, the console will still function fine.
The place owner (regardless of the universe-owner) will still see the Server Console.

This allows developers to safely use CreatePlaceInPlayerInventoryAsync, without the risk of "customers" ruining the place.
(By deleting all gamescripts, or maybe even copying everything, using the commandbar in the Server Console)
(While serverside code can be protected using require(assetId), localscripts (loaded that way or not) could still be stolen)