### PR TITLE
Fixing issue #96

### DIFF
--- a/CoreScriptsRoot/LoadingScript.lua
+++ b/CoreScriptsRoot/LoadingScript.lua
@@ -442,6 +442,8 @@ end
 function fadeBackground()
 	if not currScreenGui then return end
 	if fadingBackground then return end
+	
+	if not currScreenGui:findFirstChild("BlackFrame") then return end
 
 	fadingBackground = true
 


### PR DESCRIPTION
Fixing the error reported in issue #96 by @TheSneak
```
BlackFrame is not a valid member of ScreenGui
LoadingScript, line 451 - global fadeBackground
LoadingScript, line 519
```