### PR TITLE
Changed size of mainBackgroundContainer

### DIFF
--- a/CoreScriptsRoot/LoadingScript.lua
+++ b/CoreScriptsRoot/LoadingScript.lua
@@ -102,7 +102,7 @@ function MainGui:GenerateMain()
 	local mainBackgroundContainer = create 'Frame' {
 		Name = 'BlackFrame',
 		BackgroundColor3 = COLORS.BLACK,
-		Size = UDim2.new(1, 0, 1, 0),
+		Size = UDim2.new(1, 0, 1, 50),
 		Active = true,
 
 		create 'ImageButton' {


### PR DESCRIPTION
Both width and height were set to a scale of 1, but since the ChatBar shows up, there are extra pixels not accounted for. Just modified it so it does cover the background of the chatBar.