### PR TITLE
Fix for issue #145: BlackFrame is not a valid member of ScreenGui

### DIFF
--- a/CoreScriptsRoot/LoadingScript.lua
+++ b/CoreScriptsRoot/LoadingScript.lua
@@ -505,7 +505,7 @@ function fadeBackground()
 	local lastTime = nil
 	local backgroundRemovalTime = 3.2
 
-	while currScreenGui and currScreenGui.BlackFrame and currScreenGui.BlackFrame.BackgroundTransparency < 1 do
+	while currScreenGui and currScreenGui:FindFirstChild("BlackFrame") and currScreenGui.BlackFrame.BackgroundTransparency < 1 do
 		if lastTime == nil then
 			currScreenGui.BlackFrame.Active = false
 			lastTime = tick()


### PR DESCRIPTION
Addresses issue #145 
Line 508 is a condition for a while loop and is evaluated repeatedly. At some point BlackFrame no longer exists on currScreenGui and the condition evaluation causes an error. This fix replaces the assumed existence of BlackFrame with a check using FindFirstChild().