### PR TITLE
Fixing multiple clicktomove defects

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript.rbxmx
@@ -129,7 +129,7 @@ local function OnCameraMovementModeChange(newCameraMode)
 	if newCameraMode == Enum.DevComputerMovementMode.ClickToMove.Name then
 		ClickToMove:Start()
 		SetEnabledCamera(nil)
-		TransparencyController:SetEnabled(false)
+		TransparencyController:SetEnabled(true)
 	else
 		if newCameraMode == Enum.ComputerCameraMovementMode.Classic.Name then
 			SetEnabledCamera(ClassicCamera)

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/ClickToMove.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/ClickToMove.rbxmx
@@ -97,8 +97,9 @@ do
 	Utility.Clamp = clamp
 
 	local function ViewSizeX()
-		local x = MyMouse and MyMouse.ViewSizeX or 0
-		local y = MyMouse and MyMouse.ViewSizeY or 0
+		local camera = workspace.CurrentCamera
+		local x = camera and camera.ViewportSize.X or 0
+		local y = camera and camera.ViewportSize.Y or 0
 		if x == 0 then
 			return 1024
 		else
@@ -112,8 +113,9 @@ do
 	Utility.ViewSizeX = ViewSizeX
 
 	local function ViewSizeY()
-		local x = MyMouse and MyMouse.ViewSizeX or 0
-		local y = MyMouse and MyMouse.ViewSizeY or 0
+		local camera = workspace.CurrentCamera
+		local x = camera and camera.ViewportSize.X or 0
+		local y = camera and camera.ViewportSize.Y or 0
 		if y == 0 then
 			return 768
 		else
@@ -869,13 +871,17 @@ local function FlashRed(object)
 	end)
 end
 
-local joystickWidth = 250
-local joystickHeight = 250
+--local joystickWidth = 250
+--local joystickHeight = 250
 local function IsInBottomLeft(pt)
+	local joystickHeight = math.min(Utility.ViewSizeY() * 0.33, 250)
+	local joystickWidth = joystickHeight
 	return pt.X <= joystickWidth and pt.Y > Utility.ViewSizeY() - joystickHeight
 end
 
 local function IsInBottomRight(pt)
+	local joystickHeight = math.min(Utility.ViewSizeY() * 0.33, 250)
+	local joystickWidth = joystickHeight
 	return pt.X >= Utility.ViewSizeX() - joystickWidth and pt.Y > Utility.ViewSizeY() - joystickHeight
 end
 

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/ClickToMove.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/ClickToMove.rbxmx
@@ -1134,7 +1134,9 @@ local function CreateClickToMoveModule()
 	local HumanoidDiedConn = nil
 	local CharacterChildAddedConn = nil
 	local OnCharacterAddedConn = nil
+	local CharacterChildRemovedConn = nil
 	local RenderSteppedConn = nil
+
 
 	local function disconnectEvent(event)
 		if event then
@@ -1151,6 +1153,8 @@ local function CreateClickToMoveModule()
 		disconnectEvent(CharacterChildAddedConn)
 		disconnectEvent(OnCharacterAddedConn)
 		disconnectEvent(RenderSteppedConn)
+		disconnectEvent(CharacterChildRemovedConn)
+		pcall(function() RunService:UnbindFromRenderStep("ClickToMoveRenderUpdate") end)
 	end
 
 
@@ -1321,7 +1325,7 @@ local function CreateClickToMoveModule()
 			AutoJumperInstance = AutoJumper()
 		end
 
-		RenderSteppedConn = RunService.RenderStepped:connect(function()
+		local function Update()
 			if CameraModule then
 				if CameraModule.UserPanningTheCamera then
 					CameraModule.UpdateTweenFunction = nil
@@ -1335,7 +1339,15 @@ local function CreateClickToMoveModule()
 				end
 				CameraModule:Update()
 			end
-		end)
+		end
+		
+		local success = pcall(function() RunService:BindToRenderStep("ClickToMoveRenderUpdate",Enum.RenderPriority.Camera.Value - 1,Update) end)
+		if not success then
+			if RenderSteppedConn then
+				RenderSteppedConn:disconnect()
+			end
+			RenderSteppedConn = RunService.RenderStepped:connect(Update)
+		end
 
 		local function OnCharacterChildAdded(child)
 			if UIS.TouchEnabled then
@@ -1358,6 +1370,13 @@ local function CreateClickToMoveModule()
 		CharacterChildAddedConn = character.ChildAdded:connect(function(child)
 			OnCharacterChildAdded(child)
 		end)
+		CharacterChildRemovedConn = character.ChildRemoved:connect(function(child)
+			if UIS.TouchEnabled then
+				if child:IsA('Tool') then
+					child.ManualActivationOnly = false
+				end
+			end
+		end)
 		for _, child in pairs(character:GetChildren()) do
 			OnCharacterChildAdded(child)
 		end
@@ -1376,6 +1395,17 @@ local function CreateClickToMoveModule()
 			if CameraModule then
 				CameraModule.UpdateTweenFunction = nil
 				CameraModule:SetEnabled(false)
+			end
+			-- Restore tool activation on shutdown
+			if UIS.TouchEnabled then
+				local character = Player.Character
+				if character then
+					for _, child in pairs(character:GetChildren()) do
+						if child:IsA('Tool') then
+							child.ManualActivationOnly = false
+						end
+					end
+				end
 			end
 			Running = false
 		end


### PR DESCRIPTION
Fixing DE12448 where character occlusion does not work with ClickToMove
Fixing DE12438 where character is still visible in first person.
Fixing DE12439 where changing back from ClickToMove stops you from being able to activate tools