### PR TITLE
Fixing error

### DIFF
--- a/CoreScriptsRoot/LoadingScript.lua
+++ b/CoreScriptsRoot/LoadingScript.lua
@@ -512,7 +512,7 @@ function fadeBackground()
 	local lastTime = nil
 	local backgroundRemovalTime = 3.2
 
-	while currScreenGui and currScreenGui.BlackFrame and currScreenGui.BlackFrame.BackgroundTransparency < 1 do
+	while currScreenGui and currScreenGui:FindFirstChild("BlackFrame") and currScreenGui.BlackFrame.BackgroundTransparency < 1 do
 		if lastTime == nil then
 			currScreenGui.BlackFrame.Active = false
 			lastTime = tick()


### PR DESCRIPTION
Not sure if there was an issue open for this, since this error happened a lot due to several reasons.
This is another case where the BlackFrame error happens, due to the wrong checking for if a child is present.