### PR TITLE
Fixing issue #163

### DIFF
--- a/CoreScriptsRoot/Modules/BackpackScript.lua
+++ b/CoreScriptsRoot/Modules/BackpackScript.lua
@@ -1037,6 +1037,7 @@ end
 
 
 function changeSlot(slot)
+	if Dragging[slot.Frame] then return end -- Dragging, not meant to click
 	if slot.Frame == GuiService.SelectedCoreObject then
 		local currentlySelectedSlot = getGamepadSwapSlot()
 
@@ -1062,8 +1063,11 @@ function changeSlot(slot)
 		else
 			slot.Frame.BorderSizePixel = 1
 		end
-	else
+	elseif slot.Index <= HOTBAR_SLOTS then
 		slot:Select()
+	elseif LowestEmptySlot then
+		LowestEmptySlot:Fill(slot.Tool)
+		slot:Destroy()
 	end
 end
 


### PR DESCRIPTION
This commit will fix the reported issue #163 which happens when clicking non-hotbar slots.
With those changes, it'll ignore any clicking of slots when it is being dragged.
(As dragging a slot and releasing it counts as a click, unless it's repositioned the moment you release)
When clicking a slot in the hotbar, it'll be (de)selected, as is currently the case.
When it isn't a slot in the hotbar, while there is an empty hotbar slot available, the
clicked slot will move to the hotbar, which makes it easier to reorganise your backpack.