### PR TITLE
Fixes keyboard input canceling movement when opposing keys are pressed

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/KeyboardMovement.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/KeyboardMovement.rbxmx
@@ -57,6 +57,9 @@ function KeyboardMovement:Enable()
 		return
 	end
 	
+	local ZMovement = 0
+	local XMovement = 0
+	
 	local forwardValue  = 0
 	local backwardValue = 0
 	local leftValue = 0
@@ -64,7 +67,7 @@ function KeyboardMovement:Enable()
 	
 	local updateMovement = function()
 		MasterControl:AddToPlayerMovement(-currentMoveVector)
-		currentMoveVector = Vector3.new(leftValue + rightValue,0,forwardValue + backwardValue)
+		currentMoveVector = Vector3.new(XMovement,0,ZMovement)
 		MasterControl:AddToPlayerMovement(currentMoveVector)
 	end
 	
@@ -79,8 +82,14 @@ function KeyboardMovement:Enable()
 	local moveForwardFunc = function(actionName, inputState, inputObject)
 		if inputState == Enum.UserInputState.Begin then
 			forwardValue = -1
+			ZMovement = -1
 		elseif inputState == Enum.UserInputState.End then
 			forwardValue = 0
+			if backwardValue ~= 0 then
+				ZMovement = 1
+			else
+				ZMovement = 0
+			end
 		end
 		updateMovement()
 	end
@@ -88,8 +97,14 @@ function KeyboardMovement:Enable()
 	local moveBackwardFunc = function(actionName, inputState, inputObject)	
 		if inputState == Enum.UserInputState.Begin then
 			backwardValue = 1
+			ZMovement = 1
 		elseif inputState == Enum.UserInputState.End then
 			backwardValue = 0
+			if forwardValue ~= 0 then
+				ZMovement = -1
+			else
+				ZMovement = 0
+			end
 		end
 		updateMovement()
 	end
@@ -97,8 +112,14 @@ function KeyboardMovement:Enable()
 	local moveLeftFunc = function(actionName, inputState, inputObject)	
 		if inputState == Enum.UserInputState.Begin then
 			leftValue = -1
+			XMovement = -1
 		elseif inputState == Enum.UserInputState.End then
 			leftValue = 0
+			if rightValue ~= 0 then
+				XMovement = 1
+			else
+				XMovement = 0
+			end
 		end
 		updateMovement()
 	end
@@ -106,8 +127,14 @@ function KeyboardMovement:Enable()
 	local moveRightFunc = function(actionName, inputState, inputObject)	
 		if inputState == Enum.UserInputState.Begin then
 			rightValue = 1
+			XMovement = 1
 		elseif inputState == Enum.UserInputState.End then
 			rightValue = 0
+			if leftValue ~= 0 then
+				XMovement = -1
+			else
+				XMovement = 0
+			end
 		end
 		updateMovement()
 	end


### PR DESCRIPTION
The current behavior of player scripts is that when opposing keys are held (such as W and S) the player stops moving. This is quite jarring and dissimilar to Roblox's controls before player scripts and dissimilar to most FPS games.

This update changes behavior by using leftValue, forwardValue, rightValue, and backwardValue as indicators that a key is pressed, and uses two different directional values (one for the X axis, and one for the Z axis) to determine walk direction. When a key is pressed, the direction value associated with the key gets forced into the key's direction. When the key is released, the code checks to see if the opposite key is being held to determine what the direction value should be.