### PR TITLE
Change Game:SetMessage to Player:Kick(msg) In BuildToolManager.lua

### DIFF
--- a/CoreScriptsRoot/CoreScripts/BuildToolsScripts/BuildToolManager.lua
+++ b/CoreScriptsRoot/CoreScripts/BuildToolsScripts/BuildToolManager.lua
@@ -157,8 +157,7 @@ player.Changed:connect(function(prop)
 		if player.PersonalServerRank >= 255 then
 			giveOwnerTools()
 		elseif player.PersonalServerRank <= 0 then
-			player:Kick() -- you're banned, goodbye!
-			Game:SetMessage("You're banned from this PBS")
+			player:Kick("You're banned from this PBS") -- you're banned, goodbye!
 		end
 	end
 end)


### PR DESCRIPTION
SetMessage doesn't really need to be used due to the new :Kick(msg) function, so we are getting rid of it