### PR TITLE
Fixed PlayerList Toggle

### DIFF
--- a/CoreScriptsRoot/Modules/PlayerlistModule.lua
+++ b/CoreScriptsRoot/Modules/PlayerlistModule.lua
@@ -1892,10 +1892,6 @@ local function onCoreGuiChanged(coreGuiType, enabled)
 		end
 	end
 end
-pcall(function()
-	onCoreGuiChanged(Enum.CoreGuiType.PlayerList, game:GetService("StarterGui"):GetCoreGuiEnabled(Enum.CoreGuiType.PlayerList))
-	game:GetService("StarterGui").CoreGuiChangedSignal:connect(onCoreGuiChanged)
-end)
 
 resizePlayerList()
 
@@ -1944,6 +1940,11 @@ Playerlist.ToggleVisibility = function(name, inputState, inputObject)
 		end
 	end
 end
+
+pcall(function()
+	onCoreGuiChanged(Enum.CoreGuiType.PlayerList, game:GetService("StarterGui"):GetCoreGuiEnabled(Enum.CoreGuiType.PlayerList))
+	game:GetService("StarterGui").CoreGuiChangedSignal:connect(onCoreGuiChanged)
+end)
 
 Playerlist.IsOpen = function()
 	return isOpen


### PR DESCRIPTION
Fixed StarterGui:SetCoreGuiEnabled(Enum.CoreGuiType.PlayerList, enabled) not working properly because of a bug in PlayerList.