### PR TITLE
Fix DevMovementMode Jump Bug

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
@@ -77,7 +77,8 @@ else
 	ControlModules.Keyboard = require(script.MasterControl:WaitForChild('KeyboardMovement'))
 end
 ControlModules.Gamepad = require(script.MasterControl:WaitForChild('Gamepad'))
-if UserSettings():IsUserFeatureEnabled("UserUseLuaVehicleController") then
+local sucess, value = pcall(function() UserSettings():IsUserFeatureEnabled("UserUseLuaVehicleController") end)
+if sucess and value then
 	local VehicleController = require(script.MasterControl:WaitForChild('VehicleController')) 	-- Not used, but needs to be required
 end
 

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DPad.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DPad.rbxmx
@@ -3,6 +3,7 @@
 	<External>nil</External>
 	<Item class="ModuleScript" referent="RBX54AF403FDF86481C8A957949FBE7F81D">
 		<Properties>
+			<Content name="LinkedSource"><null></null></Content>
 			<string name="Name">DPad</string>
 			<ProtectedString name="Source"><![CDATA[--[[
 	// FileName: DPad
@@ -154,6 +155,7 @@ function DPad:Create(parentFrame)
 		
 		MasterControl:AddToPlayerMovement(-movementVector)
 		movementVector = Vector3.new(0, 0, 0)
+		MasterControl:SetIsJumping(false)
 	end
 	
 	DPadFrame.InputEnded:connect(function(inputObject)

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Gamepad.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Gamepad.rbxmx
@@ -164,6 +164,7 @@ function Gamepad:Disable()
 	
 	MasterControl:AddToPlayerMovement(-currentMoveVector)
 	currentMoveVector = Vector3.new(0,0,0)
+	MasterControl:SetIsJumping(false)
 end
 
 return Gamepad

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/KeyboardMovement.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/KeyboardMovement.rbxmx
@@ -171,6 +171,7 @@ function KeyboardMovement:Disable()
 	
 	MasterControl:AddToPlayerMovement(-currentMoveVector)
 	currentMoveVector = Vector3.new(0,0,0)
+	MasterControl:SetIsJumping(false)
 end
 
 return KeyboardMovement

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbpad.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbpad.rbxmx
@@ -3,6 +3,7 @@
 	<External>nil</External>
 	<Item class="ModuleScript" referent="RBX1E3E090B922241488CF1527B6A17D7C7">
 		<Properties>
+			<Content name="LinkedSource"><null></null></Content>
 			<string name="Name">Thumbpad</string>
 			<ProtectedString name="Source"><![CDATA[--[[
 	// FileName: Thumbpad
@@ -200,6 +201,7 @@ function Thumbpad:Create(parentFrame)
 	OnInputEnded = function()
 		MasterControl:AddToPlayerMovement(-currentMoveVector)
 		currentMoveVector = Vector3.new(0,0,0)
+		MasterControl:SetIsJumping(false)
 
 		ThumbpadFrame.Position = position
 		TouchObject = nil

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
@@ -159,6 +159,7 @@ function Thumbstick:Create(parentFrame)
 		
 		MasterControl:AddToPlayerMovement(-currentMoveVector)
 		currentMoveVector = Vector3.new(0,0,0)
+		MasterControl:SetIsJumping(false)
 	end
 	
 	OnTouchEndedCn = UserInputService.TouchEnded:connect(function(inputObject, isProcessed)


### PR DESCRIPTION
When DevComputerMovementMode is changed isJumping is not reset. isJumping should be set to false when a module is reset, like what is done with the movement vector. 