### PR TITLE
hide ContextActionService buttons when UserInputService.ModalEnabled is true

### DIFF
--- a/CoreScriptsRoot/CoreScripts/ContextActionTouch.lua
+++ b/CoreScriptsRoot/CoreScripts/ContextActionTouch.lua
@@ -5,7 +5,8 @@
 
 -- Variables
 local contextActionService = Game:GetService("ContextActionService")
-local isTouchDevice = Game:GetService("UserInputService").TouchEnabled
+local userInputService = Game:GetService("UserInputService")
+local isTouchDevice = userInputService.TouchEnabled
 local functionTable = {}
 local buttonVector = {}
 local buttonScreenGui = nil
@@ -50,6 +51,13 @@ function createContextActionGui()
 		buttonFrame.Position = UDim2.new(0.7,0,0.5,0)
 		buttonFrame.Name = "ContextButtonFrame"
 		buttonFrame.Parent = buttonScreenGui
+
+		buttonFrame.Visible = not userInputService.ModalEnabled
+		userInputService.Changed:connect(function(property)
+			if property == "ModalEnabled" then
+				buttonFrame.Visible = not userInputService.ModalEnabled
+			end
+		end)
 	end
 end
 
@@ -109,7 +117,7 @@ function createNewButton(actionName, functionInfoTable)
 
 	local currentButtonTouch = nil
 
-	Game:GetService("UserInputService").InputEnded:connect(function ( inputObject )
+	userInputService.InputEnded:connect(function ( inputObject )
 		oldTouches[inputObject] = nil
 	end)
 	contextButton.InputBegan:connect(function(inputObject)


### PR DESCRIPTION
The UserInputService.ModalEnabled property is used to hide the virtual controller and jump button on mobile devices when a modal dialog is being shown to the user. I think it should be expected behaviour for ContextActionService touch buttons to be hidden as well, especially given

* Being CoreGui, they will draw above the dialog the game wants to show to the user
* It's awkward to work around otherwise - the code for the dialog would need to tell the input code to unbind the action and then rebind it when the dialog goes away.