### PR TITLE
Various fixes

### DIFF
--- a/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
@@ -537,11 +537,12 @@ local function Initialize()
 
 		end
 
-		local adjustButton, adjustText = utility:MakeStyledButton("AdjustButton", "Adjust", UDim2.new(0,300,1,-20), showOverscanScreen)
+		local adjustButton, adjustText, setButtonRowRef = utility:MakeStyledButton("AdjustButton", "Adjust", UDim2.new(0,300,1,-20), showOverscanScreen, this)
 		adjustText.Font = Enum.Font.SourceSans
 		adjustButton.Position = UDim2.new(1,-400,0,12)
 
-		utility:AddNewRowObject(this, "Safe Zone", adjustButton)
+		local row = utility:AddNewRowObject(this, "Safe Zone", adjustButton)
+		setButtonRowRef(row)
 	end
 
 	createCameraModeOptions(not isTenFootInterface and 

--- a/CoreScriptsRoot/Modules/Settings/Pages/Help.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/Help.lua
@@ -43,8 +43,6 @@ local function Initialize()
 		if lastInputType == nil then -- we don't know what controls the user has, just use reasonable defaults
 			local platform = UserInputService:GetPlatform()
 			if platform == Enum.Platform.XBoxOne or platform == Enum.Platform.WiiU then
-				this.HubRef.PageViewClipper.ClipsDescendants = false
-				this.HubRef.PageView.ClipsDescendants = false
 				return GAMEPAD_TAG
 			elseif platform == Enum.Platform.Windows or platform == Enum.Platform.OSX then
 				return KEYBOARD_MOUSE_TAG
@@ -58,15 +56,9 @@ local function Initialize()
 			lastInputType == Enum.UserInputType.MouseButton3 or lastInputType == Enum.UserInputType.MouseWheel then
 					return KEYBOARD_MOUSE_TAG
 		elseif lastInputType == Enum.UserInputType.Touch then
-					if not utility:IsSmallTouchScreen() then
-						this.HubRef.PageViewClipper.ClipsDescendants = false
-						this.HubRef.PageView.ClipsDescendants = false
-					end
 					return TOUCH_TAG
 		elseif lastInputType == Enum.UserInputType.Gamepad1 or lastInputType == Enum.UserInputType.Gamepad2 or 
 				inputType == Enum.UserInputType.Gamepad3 or lastInputType == Enum.UserInputType.Gamepad4 then
-					this.HubRef.PageViewClipper.ClipsDescendants = false
-					this.HubRef.PageView.ClipsDescendants = false
 					return GAMEPAD_TAG
 		end
 

--- a/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
@@ -747,6 +747,9 @@ local function CreateSettingsHub()
 	function this:SwitchToPage(pageToSwitchTo, ignoreStack, direction)
 		if this.Pages.PageTable[pageToSwitchTo] == nil then return end
 
+		-- scroll back up
+		this:ScrollToProgress(0)
+
 		-- if we have a page we need to let it know to go away
 		if this.Pages.CurrentPage then
 			pageChangeCon:disconnect()

--- a/CoreScriptsRoot/Modules/Settings/Utility.lua
+++ b/CoreScriptsRoot/Modules/Settings/Utility.lua
@@ -263,7 +263,7 @@ local function MakeButton(name, text, size, clickFunc, pageRef, hubRef)
 
 		local scrollTo = button
 		if rowRef then
-
+			scrollTo = rowRef
 		end
 		local hub = hubRef
 		if hub == nil then

--- a/CoreScriptsRoot/Modules/Settings/Utility.lua
+++ b/CoreScriptsRoot/Modules/Settings/Utility.lua
@@ -254,14 +254,25 @@ local function MakeButton(name, text, size, clickFunc, pageRef, hubRef)
 		end
 	end)
 
+	local rowRef = nil
+	local function setRowRef(ref)
+		rowRef = ref
+	end
 	button.SelectionGained:connect(function()
 		button.Image = "rbxasset://textures/ui/Settings/MenuBarAssets/MenuButtonSelected.png"
 
-		if pageRef then
-			local hub = pageRef.HubRef
-			if hub then
-				hub:ScrollToFrame(button)
+		local scrollTo = button
+		if rowRef then
+
+		end
+		local hub = hubRef
+		if hub == nil then
+			if pageRef then
+				hub = pageRef.HubRef
 			end
+		end
+		if hub then
+			hub:ScrollToFrame(scrollTo)
 		end
 	end)
 	button.SelectionLost:connect(function()
@@ -305,7 +316,7 @@ local function MakeButton(name, text, size, clickFunc, pageRef, hubRef)
 		end
 	end)
 
-	return button, textLabel
+	return button, textLabel, setRowRef
 end
 
 local function CreateDropDown(dropDownStringTable, startPosition, settingsHub)
@@ -1655,7 +1666,7 @@ local function AddNewRowObject(pageToAddTo, rowDisplayName, rowObject, extraSpac
 		Active = false,
 		AutoButtonColor = false,
 		Size = UDim2.new(1,0,0,ROW_HEIGHT),
-		Position = UDim2.new(0,0,0.025,nextRowPositionY),
+		Position = UDim2.new(0,0,0,nextRowPositionY),
 		ZIndex = 2,
 		Selectable = false,
 		SelectionImageObject = noSelectionObject,

--- a/CoreScriptsRoot/Modules/TenFootInterface.lua
+++ b/CoreScriptsRoot/Modules/TenFootInterface.lua
@@ -8,6 +8,7 @@
 local HEALTH_GREEN_COLOR = Color3.new(27/255, 252/255, 107/255)
 local DISPLAY_POS_INIT_INSET = 0
 local DISPLAY_ITEM_OFFSET = 4
+local FORCE_TEN_FOOT_INTERFACE = false
 
 -------------- SERVICES --------------
 local CoreGui = game:GetService("CoreGui")
@@ -22,7 +23,11 @@ do
 
 	tenFootInterfaceEnabled = (platform == Enum.Platform.XBoxOne or platform == Enum.Platform.WiiU or platform == Enum.Platform.PS4 or 
 		platform == Enum.Platform.AndroidTV or platform == Enum.Platform.XBox360 or platform == Enum.Platform.PS3 or
-		platform == Enum.Platform.Ouya or platform == Enum.Platform.SteamOS)
+		platform == Enum.Platform.Ouya or platform == Enum.Platform.SteamOS) or FORCE_TEN_FOOT_INTERFACE
+end
+
+if FORCE_TEN_FOOT_INTERFACE then
+	
 end
 
 local Util = {}

--- a/CoreScriptsRoot/Modules/TenFootInterface.lua
+++ b/CoreScriptsRoot/Modules/TenFootInterface.lua
@@ -23,11 +23,11 @@ do
 
 	tenFootInterfaceEnabled = (platform == Enum.Platform.XBoxOne or platform == Enum.Platform.WiiU or platform == Enum.Platform.PS4 or 
 		platform == Enum.Platform.AndroidTV or platform == Enum.Platform.XBox360 or platform == Enum.Platform.PS3 or
-		platform == Enum.Platform.Ouya or platform == Enum.Platform.SteamOS) or FORCE_TEN_FOOT_INTERFACE
+		platform == Enum.Platform.Ouya or platform == Enum.Platform.SteamOS)
 end
 
 if FORCE_TEN_FOOT_INTERFACE then
-	
+	tenFootInterfaceEnabled = true
 end
 
 local Util = {}


### PR DESCRIPTION
- Fixed scrollbar clipping being disabled in ten foot mode
- Selecting buttons now properly scrolls to them
- Fixed alignment with the overscan button in the game menu
- Switching pages can no longer result in the scroll bar appearing at an
incorrect position