### PR TITLE
Lots of fixes and tweaks

### DIFF
--- a/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
+++ b/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
@@ -258,7 +258,7 @@ local function createGamepadMenuGui()
 	local settingsFunc = function()
 		toggleCoreGuiRadial()
 		local MenuModule = require(GuiRoot.Modules.Settings.SettingsHub)
-		MenuModule:SetVisibility(true)
+		MenuModule:SetVisibility(true, nil, nil, true)
 	end
 	local settingsRadial = createRadialButton("Settings", "Settings", 1, false, nil, settingsFunc)
 	settingsRadial.Parent = gamepadSettingsFrame
@@ -295,7 +295,7 @@ local function createGamepadMenuGui()
 	local leaveGameFunc = function()
 		toggleCoreGuiRadial()
 		local MenuModule = require(GuiRoot.Modules.Settings.SettingsHub)
-		MenuModule:SetVisibility(true, false, require(GuiRoot.Modules.Settings.Pages.LeaveGame))
+		MenuModule:SetVisibility(true, false, require(GuiRoot.Modules.Settings.Pages.LeaveGame), true)
 	end
 	local leaveGameRadial = createRadialButton("LeaveGame", "Leave Game", 4, false, nil, leaveGameFunc)
 	leaveGameRadial.Parent = gamepadSettingsFrame

--- a/CoreScriptsRoot/Modules/BackpackScript.lua
+++ b/CoreScriptsRoot/Modules/BackpackScript.lua
@@ -80,10 +80,6 @@ local ContextActionService = game:GetService('ContextActionService')
 local RobloxGui = CoreGui:WaitForChild('RobloxGui')
 RobloxGui:WaitForChild("Modules"):WaitForChild("TenFootInterface")
 local isTenFootInterface = require(RobloxGui.Modules.TenFootInterface):IsEnabled()
-local SettingsHub
-if useNewControllerMenu then
-	SettingsHub = require(RobloxGui.Modules.Settings:WaitForChild("SettingsHub")
-end
 
 if isTenFootInterface then
 	ICON_SIZE = 100
@@ -1449,6 +1445,13 @@ do -- Make the Inventory expand/collapse arrow (unless TopBar)
 		end
 		BackpackScript.IsOpen = InventoryFrame.Visible
 		BackpackScript.StateChanged:Fire(InventoryFrame.Visible)
+
+		if useNewControllerMenu then
+			local SettingsHub = require(RobloxGui.Modules.Settings:WaitForChild("SettingsHub"))
+			if SettingsHub.Instance.Visible then
+				SettingsHub:SetVisibility(false)
+			end
+		end
 	end
 	HotkeyFns[ARROW_HOTKEY] = openClose
 	BackpackScript.OpenClose = openClose -- Exposed

--- a/CoreScriptsRoot/Modules/BackpackScript.lua
+++ b/CoreScriptsRoot/Modules/BackpackScript.lua
@@ -68,6 +68,8 @@ local DOUBLE_CLICK_TIME = 0.5
 -----------------
 --| Variables |--
 -----------------
+local controllerMenuSuccess,controllerMenuFlagValue = pcall(function() return settings():GetFFlag("ControllerMenu") end)
+local useNewControllerMenu = (controllerMenuSuccess and controllerMenuFlagValue)
 
 local PlayersService = game:GetService('Players')
 local UserInputService = game:GetService('UserInputService')
@@ -78,6 +80,10 @@ local ContextActionService = game:GetService('ContextActionService')
 local RobloxGui = CoreGui:WaitForChild('RobloxGui')
 RobloxGui:WaitForChild("Modules"):WaitForChild("TenFootInterface")
 local isTenFootInterface = require(RobloxGui.Modules.TenFootInterface):IsEnabled()
+local SettingsHub
+if useNewControllerMenu then
+	SettingsHub = require(RobloxGui.Modules.Settings:WaitForChild("SettingsHub")
+end
 
 if isTenFootInterface then
 	ICON_SIZE = 100

--- a/CoreScriptsRoot/Modules/Chat.lua
+++ b/CoreScriptsRoot/Modules/Chat.lua
@@ -235,7 +235,7 @@ do
 	baseUrl = string.gsub(baseUrl,"/m.","/www.") --mobile site does not work for this stuff!
 	function Util.GetSecureApiBaseUrl()
 		local secureApiUrl = baseUrl
-		secureApiUrl = string.gsub(secureApiUrl,"http","https")
+		secureApiUrl = string.gsub(secureApiUrl,"http://","https://")
 		secureApiUrl = string.gsub(secureApiUrl,"www","api")
 		return secureApiUrl
 	end

--- a/CoreScriptsRoot/Modules/PlayerlistModule.lua
+++ b/CoreScriptsRoot/Modules/PlayerlistModule.lua
@@ -73,6 +73,7 @@ local MinContainerSize = UDim2.new(0, 165, 0.5, 0)
 if isTenFootInterface then
 	MinContainerSize = UDim2.new(0, 1000, 0, 720)
 end
+local TempHideKeys = {}
 
 local PlayerEntrySizeY = 24
 if isTenFootInterface then
@@ -2092,17 +2093,11 @@ local closeListFunc = function(name, state, input)
 	UserInputService.OverrideMouseIconBehavior = Enum.OverrideMouseIconBehavior.None
 end
 
-
-Playerlist.ToggleVisibility = function(name, inputState, inputObject)
-	if inputState and inputState ~= Enum.UserInputState.Begin then return end
-	if IsSmallScreenDevice then return end
-	if not game:GetService("StarterGui"):GetCoreGuiEnabled(Enum.CoreGuiType.PlayerList) then return end
-
-	isOpen = not isOpen
-	Container.Visible = isOpen
+local setVisible = function(state)
+	Container.Visible = state
 
 	if IsGamepadSupported then
-		if isOpen then
+		if state then
 			local children = ScrollList:GetChildren()
 			if children and #children > 0 then
 				local frame = children[1]
@@ -2140,8 +2135,34 @@ Playerlist.ToggleVisibility = function(name, inputState, inputObject)
 	end
 end
 
+Playerlist.ToggleVisibility = function(name, inputState, inputObject)
+	if inputState and inputState ~= Enum.UserInputState.Begin then return end
+	if IsSmallScreenDevice then return end
+	if not game:GetService("StarterGui"):GetCoreGuiEnabled(Enum.CoreGuiType.PlayerList) then return end
+
+	isOpen = not isOpen
+
+	if next(TempHideKeys) == nil then
+		setVisible(isOpen)
+	end
+end
+
 Playerlist.IsOpen = function()
 	return isOpen
+end
+
+Playerlist.HideTemp = function(self, key, hidden)
+	TempHideKeys[key] = hidden and true or nil
+
+	if next(TempHideKeys) == nil then
+		if isOpen then
+			setVisible(true)
+		end
+	else
+		if isOpen then
+			setVisible(false)
+		end
+	end
 end
 
 --[[ Core Gui Changed events ]]--
@@ -2154,7 +2175,7 @@ local function onCoreGuiChanged(coreGuiType, enabled)
 			return
 		end
 		
-		Container.Visible = enabled and isOpen
+		setVisible(enabled and isOpen and next(TempHideKeys) == nil)
 
 		if enabled then
 			ContextActionService:BindCoreAction("RbxPlayerListToggle", Playerlist.ToggleVisibility, false, Enum.KeyCode.Tab)

--- a/CoreScriptsRoot/Modules/Settings/Pages/Help.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/Help.lua
@@ -463,10 +463,7 @@ do
 	PageInstance = Initialize()
 
 	PageInstance.Displayed.Event:connect(function()
-		if PageInstance:GetCurrentInputType() == GAMEPAD_TAG then
-			PageInstance.HubRef.PageViewClipper.ClipsDescendants = false
-			PageInstance.HubRef.PageView.ClipsDescendants = false
-		elseif PageInstance:GetCurrentInputType() == TOUCH_TAG then
+		if PageInstance:GetCurrentInputType() == TOUCH_TAG then
 			if PageInstance.HubRef.BottomButtonFrame and not utility:IsSmallTouchScreen() then
 				PageInstance.HubRef.BottomButtonFrame.Visible = false
 			end
@@ -475,8 +472,6 @@ do
 
 	PageInstance.Hidden.Event:connect(function()
 		PageInstance.HubRef:ShowShield()
-		PageInstance.HubRef.PageViewClipper.ClipsDescendants = true
-		PageInstance.HubRef.PageView.ClipsDescendants = true
 		if PageInstance:GetCurrentInputType() == TOUCH_TAG then
 			PageInstance.HubRef.BottomButtonFrame.Visible = true
 		end

--- a/CoreScriptsRoot/Modules/Settings/Pages/LeaveGame.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/LeaveGame.lua
@@ -30,10 +30,21 @@ local function Initialize()
 	local settingsPageFactory = require(RobloxGui.Modules.Settings.SettingsPageFactory)
 	local this = settingsPageFactory:CreateNewPage()
 
-	this.DontLeaveFunc = function(name, state, input)
-		if this.HubRef and (not state or state == Enum.UserInputState.Begin) then
-			this.HubRef:PopMenu()
+	this.DontLeaveFunc = function(isUsingGamepad)
+		if this.HubRef then
+			this.HubRef:PopMenu(isUsingGamepad, true)
 		end
+	end
+	this.DontLeaveFromHotkey = function(name, state, input)
+		if state == Enum.UserInputState.Begin then
+			local isUsingGamepad = input.UserInputType == Enum.UserInputType.Gamepad1 or input.UserInputType == Enum.UserInputType.Gamepad2
+				or input.UserInputType == Enum.UserInputType.Gamepad3 or input.UserInputType == Enum.UserInputType.Gamepad4
+
+			this.DontLeaveFunc(isUsingGamepad)
+		end
+	end
+	this.DontLeaveFromButton = function(isUsingGamepad)
+		this.DontLeaveFunc(isUsingGamepad)
 	end
 	
 	------ TAB CUSTOMIZATION -------
@@ -82,7 +93,7 @@ local function Initialize()
 
 	------------- Init ----------------------------------
 	
-	local dontleaveGameButton = utility:MakeStyledButton("DontLeaveGame", "Don't Leave", buttonSize, this.DontLeaveFunc)
+	local dontleaveGameButton = utility:MakeStyledButton("DontLeaveGame", "Don't Leave", buttonSize, this.DontLeaveFromButton)
 	dontleaveGameButton.NextSelectionLeft = nil
 	if utility:IsSmallTouchScreen() then
 		dontleaveGameButton.Position = UDim2.new(0.5, buttonSpacing, 1, 0)
@@ -102,7 +113,7 @@ PageInstance = Initialize()
 
 PageInstance.Displayed.Event:connect(function()
 	GuiService.SelectedCoreObject = PageInstance.LeaveGameButton
-	ContextActionService:BindCoreAction(LEAVE_GAME_ACTION, PageInstance.DontLeaveFunc, false, Enum.KeyCode.ButtonB)
+	ContextActionService:BindCoreAction(LEAVE_GAME_ACTION, PageInstance.DontLeaveFromHotkey, false, Enum.KeyCode.ButtonB)
 end)
 
 PageInstance.Hidden.Event:connect(function()

--- a/CoreScriptsRoot/Modules/Settings/Pages/Record.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/Record.lua
@@ -12,7 +12,9 @@ local Settings = UserSettings()
 local GameSettings = Settings.GameSettings
 
 ----------- UTILITIES --------------
+RobloxGui:WaitForChild("Modules"):WaitForChild("TenFootInterface")
 local utility = require(RobloxGui.Modules.Settings.Utility)
+local isTenFootInterface = require(RobloxGui.Modules.TenFootInterface):IsEnabled()
 
 ------------ Variables -------------------
 local PageInstance = nil
@@ -129,15 +131,20 @@ local function Initialize()
 		recordButton.Position = UDim2.new(0,410,1,10)
 		recordButton.Parent = this.VideoSettingsMode.SelectorFrame.Parent
 		recordButton.MouseButton1Click:connect(function()
-			isRecordingVideo = not isRecordingVideo
-			if isRecordingVideo then
-				recordButton.RecordButtonTextLabel.Text = "Stop Recording"
-			else
-				recordButton.RecordButtonTextLabel.Text = "Record Video"
-			end
-			recordingEvent:Fire(isRecordingVideo)
+			recordingEvent:Fire(not isRecordingVideo)
 		end)
 
+		local gameOptions = settings():FindFirstChild("Game Options")
+		if gameOptions then
+			gameOptions.VideoRecordingChangeRequest:connect(function(recording)
+				isRecordingVideo = recording
+				if recording then
+					recordButton.RecordButtonTextLabel.Text = "Stop Recording"
+				else
+					recordButton.RecordButtonTextLabel.Text = "Record Video"
+				end
+			end)
+		end
 
 
 		recordButton:SetVerb("RecordToggle")
@@ -153,8 +160,10 @@ end
 ----------- Public Facing API Additions --------------
 PageInstance = Initialize()
 
-PageInstance.Displayed.Event:connect(function()
-	GuiService.SelectedCoreObject = PageInstance.ScreenshotButton
+PageInstance.Displayed.Event:connect(function(switchedFromGamepadInput)
+	if switchedFromGamepadInput then
+		GuiService.SelectedCoreObject = PageInstance.ScreenshotButton
+	end
 end)
 
 

--- a/CoreScriptsRoot/Modules/Settings/Pages/ReportAbuseMenu.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/ReportAbuseMenu.lua
@@ -218,7 +218,7 @@ local function Initialize()
 			end
 		end
 
-		submitButton, submitText = utility:MakeStyledButton("SubmitButton", "Submit", UDim2.new(0,194,0,50), onReportSubmitted, this)
+		submitButton, submitText = utility:MakeStyledButton("SubmitButton", "Submit", UDim2.new(0,198,0,50), onReportSubmitted, this)
 		if utility:IsSmallTouchScreen() then
 			submitButton.Position = UDim2.new(1,-220,1,5)
 		else

--- a/CoreScriptsRoot/Modules/Settings/Pages/ResetCharacter.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/ResetCharacter.lua
@@ -28,10 +28,21 @@ local function Initialize()
 	local settingsPageFactory = require(RobloxGui.Modules.Settings.SettingsPageFactory)
 	local this = settingsPageFactory:CreateNewPage()
 
-	this.DontResetCharFunc = function(name, state, input)
-		if this.HubRef and (not state or state == Enum.UserInputState.Begin) then
-			this.HubRef:PopMenu()
+	this.DontResetCharFunc = function(isUsingGamepad)
+		if this.HubRef then
+			this.HubRef:PopMenu(isUsingGamepad, true)
 		end
+	end
+	this.DontResetCharFromHotkey = function(name, state, input)
+		if state == Enum.UserInputState.Begin then
+			local isUsingGamepad = input.UserInputType == Enum.UserInputType.Gamepad1 or input.UserInputType == Enum.UserInputType.Gamepad2
+				or input.UserInputType == Enum.UserInputType.Gamepad3 or input.UserInputType == Enum.UserInputType.Gamepad4
+
+			this.DontResetCharFunc(isUsingGamepad)
+		end
+	end
+	this.DontResetCharFromButton = function(isUsingGamepad)
+		this.DontResetCharFunc(isUsingGamepad)
 	end
 	
 	------ TAB CUSTOMIZATION -------
@@ -95,7 +106,7 @@ local function Initialize()
 	this.ResetCharacterButton.Parent = resetCharacterText
 
 
-	local dontResetCharacterButton = utility:MakeStyledButton("DontResetCharacter", "Don't Reset", buttonSize, this.DontResetCharFunc)
+	local dontResetCharacterButton = utility:MakeStyledButton("DontResetCharacter", "Don't Reset", buttonSize, this.DontResetCharFromButton)
 	dontResetCharacterButton.NextSelectionLeft = nil
 	if utility:IsSmallTouchScreen() then
 		dontResetCharacterButton.Position = UDim2.new(0.5, buttonSpacing, 1, 0)
@@ -115,7 +126,7 @@ PageInstance = Initialize()
 
 PageInstance.Displayed.Event:connect(function()
 	GuiService.SelectedCoreObject = PageInstance.ResetCharacterButton
-	ContextActionService:BindCoreAction(RESET_CHARACTER_GAME_ACTION, PageInstance.DontResetCharFunc, false, Enum.KeyCode.ButtonB)
+	ContextActionService:BindCoreAction(RESET_CHARACTER_GAME_ACTION, PageInstance.DontResetCharFromHotkey, false, Enum.KeyCode.ButtonB)
 end)
 
 PageInstance.Hidden.Event:connect(function()

--- a/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
@@ -223,7 +223,7 @@ local function CreateSettingsHub()
 			Name = 'Modal',
 			BackgroundTransparency = 1,
 			Position = UDim2.new(0, 0, 1, -1),
-			Size = UDim2.new(0, 1, 0, 1),
+			Size = UDim2.new(1, 0, 1, 0),
 			Modal = true,
 			Text = '',
 			Parent = this.Shield
@@ -820,7 +820,7 @@ local function CreateSettingsHub()
 		end
 	end
 
-	function this:SwitchToPage(pageToSwitchTo, ignoreStack, direction, autoSelectRow, skipAnimation) print('switch',skipAnimation)
+	function this:SwitchToPage(pageToSwitchTo, ignoreStack, direction, autoSelectRow, skipAnimation)
 		if this.Pages.PageTable[pageToSwitchTo] == nil then return end
 
 		-- detect direction
@@ -954,9 +954,7 @@ local function CreateSettingsHub()
 				end
 			end
 
-			if playerList:IsOpen() then
-				playerList:ToggleVisibility()
-			end
+			playerList:HideTemp('SettingsMenu', true)
 
 			if chat:GetVisibility() then
 				chat:ToggleVisibility()
@@ -978,6 +976,8 @@ local function CreateSettingsHub()
 			if lastInputChangedCon then
 				lastInputChangedCon:disconnect()
 			end
+
+			playerList:HideTemp('SettingsMenu', false)
 
 			pcall(function() UserInputService.OverrideMouseIconBehavior = Enum.OverrideMouseIconBehavior.None end)
 			pcall(function() PlatformService.BlurIntensity = 0 end)
@@ -1009,7 +1009,7 @@ local function CreateSettingsHub()
 	end
 
 
-	function this:PopMenu(switchedFromGamepadInput, skipAnimation) print('pop',skipAnimation)
+	function this:PopMenu(switchedFromGamepadInput, skipAnimation)
 		if this.MenuStack and #this.MenuStack > 0 then
 			local lastStackItem = this.MenuStack[#this.MenuStack]
 
@@ -1155,5 +1155,7 @@ local moduleApiTable = {}
 	end
 
 	moduleApiTable.SettingsShowSignal = SettingsHubInstance.SettingsShowSignal
+
+	moduleApiTable.Instance = SettingsHubInstance
 
 return moduleApiTable

--- a/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
@@ -53,9 +53,11 @@ local function CreateSettingsHub()
 	this.MenuStack = {}
 	this.TabHeaders = {}
 	this.BottomBarButtons = {}
+	this.TabConnection = nil
 	this.LeaveGamePage = require(RobloxGui.Modules.Settings.Pages.LeaveGame)
 	this.ResetCharacterPage = require(RobloxGui.Modules.Settings.Pages.ResetCharacter)
 	this.SettingsShowSignal = utility:CreateSignal()
+	this.OpenStateChangedCount = 0
 
 	local pageChangeCon = nil
 
@@ -76,13 +78,22 @@ local function CreateSettingsHub()
 		end
 	end
 
-	local function removeBottomBarBindings()
+	local function removeBottomBarBindings(delayBeforeRemoving)
 		for _, hotKeyTable in pairs(this.BottomBarButtons) do
 			ContextActionService:UnbindCoreAction(hotKeyTable[1])
 		end
 
-		if this.BottomButtonFrame then
-			this.BottomButtonFrame.Visible = false
+		local myOpenStateChangedCount = this.OpenStateChangedCount
+		local remove = function()
+			if this.OpenStateChangedCount == myOpenStateChangedCount and this.BottomButtonFrame then
+				this.BottomButtonFrame.Visible = false
+			end
+		end
+
+		if delayBeforeRemoving then
+			delay(delayBeforeRemoving, remove)
+		else
+			remove()
 		end
 	end
 
@@ -207,6 +218,17 @@ local function CreateSettingsHub()
 			Parent = clippingShield
 		};
 
+		this.Modal = utility:Create'TextButton' -- Force unlocks the mouse, really need a way to do this via UIS
+		{
+			Name = 'Modal',
+			BackgroundTransparency = 1,
+			Position = UDim2.new(0, 0, 1, -1),
+			Size = UDim2.new(0, 1, 0, 1),
+			Modal = true,
+			Text = '',
+			Parent = this.Shield
+		}
+
 		this.HubBar = utility:Create'ImageLabel'
 		{
 			Name = "HubBar",
@@ -329,14 +351,14 @@ local function CreateSettingsHub()
 				this:AddToMenuStack(this.Pages.CurrentPage)
 				this.HubBar.Visible = false
 				removeBottomBarBindings()
-				this:SwitchToPage(this.LeaveGamePage, nil, 1)
+				this:SwitchToPage(this.LeaveGamePage, nil, 1, isTenFootInterface, true)
 			end
 
 			local resetCharFunc = function()
 				this:AddToMenuStack(this.Pages.CurrentPage)
 				this.HubBar.Visible = false
 				removeBottomBarBindings()
-				this:SwitchToPage(this.ResetCharacterPage, nil, 1)
+				this:SwitchToPage(this.ResetCharacterPage, nil, 1, isTenFootInterface, true)
 			end
 
 			local resumeFunc = function()
@@ -588,35 +610,87 @@ local function CreateSettingsHub()
 		end
 	end
 
+	local lastInputUsedToSelectGui = isTenFootInterface
+	UserInputService.InputBegan:connect(function(input)
+		if input.UserInputType == Enum.UserInputType.Gamepad1 or input.UserInputType == Enum.UserInputType.Gamepad2 or input.UserInputType == Enum.UserInputType.Gamepad3 or input.UserInputType == Enum.UserInputType.Gamepad4
+			or input.KeyCode == Enum.KeyCode.Left or input.KeyCode == Enum.KeyCode.Right or input.KeyCode == Enum.KeyCode.Up or input.KeyCode == Enum.KeyCode.Down or input.KeyCode == Enum.KeyCode.Tab then
+			lastInputUsedToSelectGui = true
+		elseif input.UserInputType == Enum.UserInputType.Touch or input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.MouseButton2 then
+			lastInputUsedToSelectGui = false
+		end
+	end)
+	UserInputService.InputChanged:connect(function(input)
+		if input.KeyCode == Enum.KeyCode.Thumbstick1 or input.KeyCode == Enum.KeyCode.Thumbstick2 then
+			if input.Position.magnitude >= 0.25 then
+				lastInputUsedToSelectGui = true
+			end
+		elseif input.UserInputType == Enum.UserInputType.Touch or input.UserInputType == Enum.UserInputType.MouseMovement then
+			lastInputUsedToSelectGui = false
+		end
+	end)
 
-	local switchTabFunc = function(actionName, inputState, inputObject)
+
+	local switchTab = function(direction, cycle, autoSelectRow)
+		local currentTabPosition = GetHeaderPosition(this.Pages.CurrentPage)
+		if currentTabPosition < 0 then return end
+
+		local newTabPosition = currentTabPosition + direction
+		if cycle then
+			if newTabPosition > #this.TabHeaders then
+				newTabPosition = 1
+			elseif newTabPosition < 1 then
+				newTabPosition = #this.TabHeaders
+			end
+		end
+		local newHeader = this.TabHeaders[newTabPosition]
+
+		if newHeader then
+			for pager,v in pairs(this.Pages.PageTable) do
+				if pager:GetTabHeader() == newHeader then
+					this:SwitchToPage(pager, true, direction, autoSelectRow)
+					break
+				end
+			end
+		end
+	end
+
+	local switchTabFromBumpers = function(actionName, inputState, inputObject)
 		if inputState ~= Enum.UserInputState.Begin then return end
 
 		local direction = 0
-		if inputObject.KeyCode == Enum.KeyCode.ButtonR1 or inputObject.KeyCode == Enum.KeyCode.Tab then 
+		if inputObject.KeyCode == Enum.KeyCode.ButtonR1 then 
 			direction = 1
 		elseif inputObject.KeyCode == Enum.KeyCode.ButtonL1 then 
 			direction = -1
 		end
 
-		local currentTabPosition = GetHeaderPosition(this.Pages.CurrentPage)
-		if currentTabPosition < 0 then return end
+		switchTab(direction, true, true)
+	end
 
-		local newTabPosition = currentTabPosition + direction
-		local newHeader = this.TabHeaders[newTabPosition]
-
-		if not newHeader and inputObject.KeyCode == Enum.KeyCode.Tab then
-			newHeader = this.TabHeaders[1]
-		end
-
-		if newHeader then
-			for pager,v in pairs(this.Pages.PageTable) do
-				if pager:GetTabHeader() == newHeader then
-					this:SwitchToPage(pager, true, direction)
-					break
-				end
+	local switchTabFromKeyboard = function(input)
+		if input.KeyCode == Enum.KeyCode.Tab then
+			local direction = 0
+			if UserInputService:IsKeyDown(Enum.KeyCode.LeftShift) or UserInputService:IsKeyDown(Enum.KeyCode.RightShift) then
+				direction = -1
+			else
+				direction = 1
 			end
+
+			switchTab(direction, true, true)
 		end
+	end
+
+	local scrollHotkeyFunc = function(actionName, inputState, inputObject)
+		if inputState ~= Enum.UserInputState.Begin then return end
+
+		local direction = 0
+		if inputObject.KeyCode == Enum.KeyCode.PageUp then
+			direction = -100
+		elseif inputObject.KeyCode == Enum.KeyCode.PageDown then
+			direction = 100
+		end
+
+		this:ScrollPixels(direction)
 	end
 
 	-- need some stuff for functions below so init here
@@ -733,19 +807,31 @@ local function CreateSettingsHub()
 		this.PageView.CanvasPosition = Vector2.new(0, newY)
 	end
 
-	function this:ScrollToFrame(frame)
-		local ay = frame.AbsolutePosition.y - this.Pages.CurrentPage.Page.AbsolutePosition.y
-		local by = ay + frame.AbsoluteSize.y
+	function this:ScrollToFrame(frame, forced)
+		if lastInputUsedToSelectGui or forced then
+			local ay = frame.AbsolutePosition.y - this.Pages.CurrentPage.Page.AbsolutePosition.y
+			local by = ay + frame.AbsoluteSize.y
 
-		if ay < this.PageView.CanvasPosition.y then -- Scroll up to fit top
-			this.PageView.CanvasPosition = Vector2.new(0, ay)
-		elseif by - this.PageView.CanvasPosition.y > this.PageViewClipper.Size.Y.Offset then -- Scroll down to fit bottom
-			this.PageView.CanvasPosition = Vector2.new(0, by - this.PageViewClipper.Size.Y.Offset)
+			if ay < this.PageView.CanvasPosition.y then -- Scroll up to fit top
+				this.PageView.CanvasPosition = Vector2.new(0, ay)
+			elseif by - this.PageView.CanvasPosition.y > this.PageViewClipper.Size.Y.Offset then -- Scroll down to fit bottom
+				this.PageView.CanvasPosition = Vector2.new(0, by - this.PageViewClipper.Size.Y.Offset)
+			end
 		end
 	end
 
-	function this:SwitchToPage(pageToSwitchTo, ignoreStack, direction)
+	function this:SwitchToPage(pageToSwitchTo, ignoreStack, direction, autoSelectRow, skipAnimation) print('switch',skipAnimation)
 		if this.Pages.PageTable[pageToSwitchTo] == nil then return end
+
+		-- detect direction
+		if direction == nil then
+			if this.Pages.CurrentPage and this.Pages.CurrentPage.TabHeader and pageToSwitchTo and pageToSwitchTo.TabHeader then
+				direction = this.Pages.CurrentPage.TabHeader.AbsolutePosition.x < pageToSwitchTo.TabHeader.AbsolutePosition.x and 1 or -1
+			end
+		end
+		if direction == nil then
+			direction = 1
+		end
 
 		-- scroll back up
 		this:ScrollToProgress(0)
@@ -760,7 +846,7 @@ local function CreateSettingsHub()
 		local newPagePos = pageToSwitchTo.TabPosition
 		for page, _ in pairs(this.Pages.PageTable) do
 			if page ~= pageToSwitchTo then
-				page:Hide(-direction, newPagePos)
+				page:Hide(-direction, newPagePos, skipAnimation)
 			end
 		end
 
@@ -771,7 +857,7 @@ local function CreateSettingsHub()
 
 		-- make sure page is visible
 		this.Pages.CurrentPage = pageToSwitchTo
-		this.Pages.CurrentPage:Display(this.PageView)
+		this.Pages.CurrentPage:Display(this.PageView, autoSelectRow, skipAnimation)
 		this.Pages.CurrentPage.Active = true
 
 		local pageSize = this.Pages.CurrentPage:GetSize()
@@ -813,10 +899,19 @@ local function CreateSettingsHub()
 		end)
 	end
 
-	function setVisibilityInternal(visible, noAnimation, customStartPage)
+	function setVisibilityInternal(visible, noAnimation, customStartPage, switchedFromGamepadInput)
+		this.OpenStateChangedCount = this.OpenStateChangedCount + 1
+		local switchedFromGamepadInput = switchedFromGamepadInput or isTenFootInterface
 		this.Visible = visible
 
 		this.SettingsShowSignal:fire(this.Visible)
+
+		this.Modal.Visible = this.Visible
+
+		if this.TabConnection then
+			this.TabConnection:disconnect()
+			this.TabConnection = nil
+		end
 
 		if this.Visible then
 			this.Shield.Visible = this.Visible
@@ -833,10 +928,16 @@ local function CreateSettingsHub()
 												 Enum.PlayerActions.CharacterLeft,
 												 Enum.PlayerActions.CharacterRight,
 												 Enum.PlayerActions.CharacterJump, 
+												 Enum.KeyCode.LeftShift,
+												 Enum.KeyCode.RightShift,
+												 Enum.KeyCode.Tab,
 												 Enum.UserInputType.Gamepad1, Enum.UserInputType.Gamepad2, Enum.UserInputType.Gamepad3, Enum.UserInputType.Gamepad4)
 
-			ContextActionService:BindCoreAction("RbxSettingsHubSwitchTab", switchTabFunc, false, Enum.KeyCode.ButtonR1, Enum.KeyCode.ButtonL1, Enum.KeyCode.Tab)
+			ContextActionService:BindCoreAction("RbxSettingsHubSwitchTab", switchTabFromBumpers, false, Enum.KeyCode.ButtonR1, Enum.KeyCode.ButtonL1)
+			ContextActionService:BindCoreAction("RbxSettingsScrollHotkey", scrollHotkeyFunc, false, Enum.KeyCode.PageUp, Enum.KeyCode.PageDown)
 			setBottomBarBindings()
+
+			this.TabConnection = UserInputService.InputBegan:connect(switchTabFromKeyboard)
 
 			setOverrideMouseIconBehavior()
 			pcall(function() lastInputChangedCon = UserInputService.LastInputTypeChanged:connect(setOverrideMouseIconBehavior) end)
@@ -844,12 +945,12 @@ local function CreateSettingsHub()
 			pcall(function() PlatformService.BlurIntensity = 10 end)
 
 			if customStartPage then
-				this:SwitchToPage(customStartPage, nil, 1)
+				this:SwitchToPage(customStartPage, nil, 1, switchedFromGamepadInput, true)
 			else
 				if this.HomePage then
-					this:SwitchToPage(this.HomePage, nil, 1)
+					this:SwitchToPage(this.HomePage, nil, 1, switchedFromGamepadInput, true)
 				else
-					this:SwitchToPage(this.GameSettingsPage, nil, 1)
+					this:SwitchToPage(this.GameSettingsPage, nil, 1, switchedFromGamepadInput, true)
 				end
 			end
 
@@ -884,21 +985,21 @@ local function CreateSettingsHub()
 			clearMenuStack()
 			ContextActionService:UnbindCoreAction("RbxSettingsHubSwitchTab")
 			ContextActionService:UnbindCoreAction("RbxSettingsHubStopCharacter")
-			removeBottomBarBindings()
+			ContextActionService:UnbindCoreAction("RbxSettingsScrollHotkey")
+			removeBottomBarBindings(0.4)
 
 			game.GuiService.SelectedCoreObject = nil
 		end
-
 	end
 
-	function this:SetVisibility(visible, noAnimation, customStartPage)
+	function this:SetVisibility(visible, noAnimation, customStartPage, switchedFromGamepadInput)
 		if this.Visible == visible then return end
 
-		setVisibilityInternal(visible, noAnimation, customStartPage)
+		setVisibilityInternal(visible, noAnimation, customStartPage, switchedFromGamepadInput)
 	end
 
-	function this:ToggleVisibility()
-		setVisibilityInternal(not this.Visible)
+	function this:ToggleVisibility(switchedFromGamepadInput)
+		setVisibilityInternal(not this.Visible, nil, nil, switchedFromGamepadInput)
 	end
 
 	function this:AddToMenuStack(newItem)
@@ -908,7 +1009,7 @@ local function CreateSettingsHub()
 	end
 
 
-	function this:PopMenu()
+	function this:PopMenu(switchedFromGamepadInput, skipAnimation) print('pop',skipAnimation)
 		if this.MenuStack and #this.MenuStack > 0 then
 			local lastStackItem = this.MenuStack[#this.MenuStack]
 
@@ -921,10 +1022,10 @@ local function CreateSettingsHub()
 			end
 
 			table.remove(this.MenuStack, #this.MenuStack)
-			this:SwitchToPage(this.MenuStack[#this.MenuStack], true, 1)
+			this:SwitchToPage(this.MenuStack[#this.MenuStack], true, 1, switchedFromGamepadInput, skipAnimation)
 			if #this.MenuStack == 0 then
 				this:SetVisibility(false)
-				this.Pages.CurrentPage:Hide(0,0)
+				this.Pages.CurrentPage:Hide(0, 0)--, true, 0.4)
 			end
 		else
 			this.MenuStack = {}
@@ -942,7 +1043,7 @@ local function CreateSettingsHub()
 
 	local closeMenuFunc = function(name, inputState, input)
 		if inputState ~= Enum.UserInputState.Begin then return end
-		this:PopMenu()
+		this:PopMenu(false, true)
 	end
 	ContextActionService:BindCoreAction("RBXEscapeMainMenu", closeMenuFunc, false, Enum.KeyCode.Escape)
 	
@@ -987,16 +1088,16 @@ local function CreateSettingsHub()
 	end
 
 	if this.HomePage then
-		this:SwitchToPage(this.HomePage, true, 1)
+		this:SwitchToPage(this.HomePage, true, 1, isTenFootInterface)
 	else
-		this:SwitchToPage(this.GameSettingsPage, true, 1)
+		this:SwitchToPage(this.GameSettingsPage, true, 1, isTenFootInterface)
 	end
 	-- hook up to necessary signals
 
 	-- connect back button on android
 	GuiService.ShowLeaveConfirmation:connect(function()
 		if #this.MenuStack == 0 then
-			this:SwitchToPage(this.LeaveGamePage, nil, 1)
+			this:SwitchToPage(this.LeaveGamePage, nil, 1, isTenFootInterface)
 		else
 			this:SetVisibility(false)
 			this:PopMenu()
@@ -1005,6 +1106,19 @@ local function CreateSettingsHub()
 
 	-- Dev Console Connections
 	ContextActionService:BindCoreAction(DEV_CONSOLE_ACTION_NAME, toggleDevConsole, false, Enum.KeyCode.F9)
+
+	-- Keyboard control
+	UserInputService.InputBegan:connect(function(input)
+		if input.KeyCode == Enum.KeyCode.Left or input.KeyCode == Enum.KeyCode.Right or input.KeyCode == Enum.KeyCode.Up or input.KeyCode == Enum.KeyCode.Down then
+			if this.Visible and this.Active then
+				if this.Pages.CurrentPage then
+					if GuiService.SelectedCoreObject == nil then
+						this.Pages.CurrentPage:SelectARow()
+					end
+				end
+			end
+		end
+	end)
 
 	return this
 end
@@ -1016,16 +1130,16 @@ local moduleApiTable = {}
 
 	local SettingsHubInstance = CreateSettingsHub()
 
-	function moduleApiTable:SetVisibility(visible, noAnimation, customStartPage)
-		SettingsHubInstance:SetVisibility(visible, noAnimation, customStartPage)
+	function moduleApiTable:SetVisibility(visible, noAnimation, customStartPage, switchedFromGamepadInput)
+		SettingsHubInstance:SetVisibility(visible, noAnimation, customStartPage, switchedFromGamepadInput)
 	end
 
-	function moduleApiTable:ToggleVisibility()
-		SettingsHubInstance:ToggleVisibility()
+	function moduleApiTable:ToggleVisibility(switchedFromGamepadInput)
+		SettingsHubInstance:ToggleVisibility(switchedFromGamepadInput)
 	end
 
-	function moduleApiTable:SwitchToPage(pageToSwitchTo, ignoreStack)
-		SettingsHubInstance:SwitchToPage(pageToSwitchTo, ignoreStack, 1)
+	function moduleApiTable:SwitchToPage(pageToSwitchTo, ignoreStack, switchedFromGamepadInput)
+		SettingsHubInstance:SwitchToPage(pageToSwitchTo, ignoreStack, 1, switchedFromGamepadInput)
 	end
 
 	function moduleApiTable:GetVisibility()

--- a/CoreScriptsRoot/Modules/Settings/SettingsPageFactory.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsPageFactory.lua
@@ -154,7 +154,7 @@ local function Initialize()
 		end
 	end
 
-	function this:Display(pageParent, autoSelectRow, skipAnimation) print('display skip',skipAnimation)
+	function this:Display(pageParent, autoSelectRow, skipAnimation)
 		this.OpenStateChangedCount = this.OpenStateChangedCount + 1
 
 		if this.TabHeader then
@@ -179,7 +179,7 @@ local function Initialize()
 			this.Page:TweenPosition(endPos, Enum.EasingDirection.In, Enum.EasingStyle.Quad, 0.1, true, animationComplete)
 		end
 	end
-	function this:Hide(direction, newPagePos, skipAnimation, delayBeforeHiding) print('hide skip',skipAnimation)
+	function this:Hide(direction, newPagePos, skipAnimation, delayBeforeHiding)
 		this.OpenStateChangedCount = this.OpenStateChangedCount + 1
 
 		if this.TabHeader then


### PR DESCRIPTION
- Mouse leaving the currently selected row now deselects it
- Switching pages now only auto selects the first item when you switched using a gamepad input type
- Report submit button is now aligned
- Report submit button no longer highlights while drop down selector is open
- Selector carousels no longer have a debounce
- No longer auto scrolls to highlighted rows when using mouse and keyboard or touch
- Text box now instantly deselects if you leave focus while the mouse is no longer hovering over the row
- Fixed mouse hover detection size on text box to encompass the text box
- Clicking on the inside of a selector carousel is no longer completely broken, it selects the next item in the list
- Fixed initial slider state so they don't flash when a row is selected for the first time
- Removed ugly tween between regular pages and special pages (leave and reset)
- Fixed clipping sometimes failing (for real this time)
- Fixed scroll bar alignment
- Menu elements no longer start disappearing before the menu is fully closed
- Menus now tween out to the correct direction
- Mouse is now unlocked from first person, mouselock, etc while in the menu
- Bumper buttons can loop around the tab buttons
- Shift+tab cycles menus to the left (does not work at the moment because of a client bug)
- Using tab to advance to the next page auto selects the first item on the page or the most recently selected item
- Pressing an arrow key will auto select the first item on the page
- Using the arrow keys to select a row will auto scroll to that row
- Shift keys get absorbed while the menu is open so the player won't toggle mouselock while tabbing between menus
- PageUp and PageDown keys now act as hotkeys to scroll
- Drop down menus can be navigated using the arrow and enter keys
- Backpack and settings can no longer be open simultaneously
- Player list and settings can no longer be open simultaneously
