### PR TITLE
Fixed hurt overlay showing when health CoreGui was disabled

### DIFF
--- a/CoreScriptsRoot/CoreScripts/Topbar.lua
+++ b/CoreScriptsRoot/CoreScripts/Topbar.lua
@@ -465,7 +465,7 @@ local function CreateUsernameHealthMenuItem()
 				local healthColor = HealthbarColorTransferFunction(healthPercent)
 				local thresholdForHurtOverlay = humanoid.MaxHealth * HEALTH_PERCANTAGE_FOR_OVERLAY
 
-				if healthDelta >= thresholdForHurtOverlay and health ~= humanoid.MaxHealth then
+				if healthDelta >= thresholdForHurtOverlay and health ~= humanoid.MaxHealth and game.StarterGui:GetCoreGuiEnabled("Health") == true then
 					AnimateHurtOverlay()
 				end
 				


### PR DESCRIPTION
Whenever the player takes a significant amount of damage, the topbar
CoreScript flashes a hurt overlay. The only problem was that even if the
health CoreGui was disabled, this hurt overlay still flashed. This adds
an extra check to make sure the hurt overlay is not used when the health
CoreGui is disabled.