### PR TITLE
Remember pevious GuiNavigationEnabled value in menu

### DIFF
--- a/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
+++ b/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
@@ -28,6 +28,10 @@ local isTenFootInterface = tenFootInterface:IsEnabled()
 local radialButtons = {}
 local lastInputChangedCon = nil
 
+--[[ FLAGS ]]
+local coreGuiNavigationSuccess, coreGuiNavigationFlagValue = pcall(function() return settings():GetFFlag("CoreGuiDescendantsAlwaysSelectable") end)
+local coreGuiNavigationAlwaysEnabled = coreGuiNavigationSuccess and coreGuiNavigationFlagValue
+
 local function getButtonForCoreGuiType(coreGuiType)
 	if coreGuiType == Enum.CoreGuiType.All then
 		return radialButtons
@@ -402,8 +406,11 @@ local function setupGamepadControls()
 
 	local noOpFunc = function() end
 	local doGamepadMenuButton = nil
-	
+
 	function unbindAllRadialActions()
+		if not coreGuiNavigationAlwaysEnabled then
+			GuiService.GuiNavigationEnabled = true
+		end
 		ContextActionService:UnbindCoreAction(radialSelectActionName)
 		ContextActionService:UnbindCoreAction(radialCancelActionName)
 		ContextActionService:UnbindCoreAction(radialAcceptActionName)
@@ -573,6 +580,9 @@ local function setupGamepadControls()
 
 		if isVisible then
 			setSelectedRadialButton(nil)
+			if not coreGuiNavigationAlwaysEnabled then
+				GuiService.GuiNavigationEnabled = false
+			end
 
 			pcall(function() GuiService:SetMenuIsOpen(true) end)
 

--- a/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
+++ b/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
@@ -402,10 +402,8 @@ local function setupGamepadControls()
 
 	local noOpFunc = function() end
 	local doGamepadMenuButton = nil
-	local previousGuiNavigationEnabledValue = true
 	
 	function unbindAllRadialActions()
-		GuiService.GuiNavigationEnabled = previousGuiNavigationEnabledValue
 		ContextActionService:UnbindCoreAction(radialSelectActionName)
 		ContextActionService:UnbindCoreAction(radialCancelActionName)
 		ContextActionService:UnbindCoreAction(radialAcceptActionName)
@@ -575,8 +573,6 @@ local function setupGamepadControls()
 
 		if isVisible then
 			setSelectedRadialButton(nil)
-			previousGuiNavigationEnabledValue = GuiService.GuiNavigationEnabled
-			GuiService.GuiNavigationEnabled = false
 
 			pcall(function() GuiService:SetMenuIsOpen(true) end)
 

--- a/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
+++ b/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
@@ -402,9 +402,10 @@ local function setupGamepadControls()
 
 	local noOpFunc = function() end
 	local doGamepadMenuButton = nil
-
+	local previousGuiNavigationEnabledValue = true
+	
 	function unbindAllRadialActions()
-		GuiService.GuiNavigationEnabled = true
+		GuiService.GuiNavigationEnabled = previousGuiNavigationEnabledValue
 		ContextActionService:UnbindCoreAction(radialSelectActionName)
 		ContextActionService:UnbindCoreAction(radialCancelActionName)
 		ContextActionService:UnbindCoreAction(radialAcceptActionName)
@@ -574,6 +575,7 @@ local function setupGamepadControls()
 
 		if isVisible then
 			setSelectedRadialButton(nil)
+			previousGuiNavigationEnabledValue = GuiService.GuiNavigationEnabled
 			GuiService.GuiNavigationEnabled = false
 
 			pcall(function() GuiService:SetMenuIsOpen(true) end)


### PR DESCRIPTION
More details on this bug : http://devforum.roblox.com/t/escape-menu-doenst-revert-changes-made-to-guiservice-on-close/19938