### PR TITLE
Fix "success when already owning asset"

### DIFF
--- a/CoreScriptsRoot/CoreScripts/PurchasePromptScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/PurchasePromptScript2.lua
@@ -1017,7 +1017,7 @@ local function canPurchase()
 			ItemDescriptionText.Text = PURCHASE_MSG.ALREADY_OWN
 			PostBalanceText.Visible = false
 			setButtonsVisible(OkButton)
-			return true
+			return false
 		end
 		
 		-- most places will not need to sell third party assets.


### PR DESCRIPTION
Reported by Nikilis on RBXDev:
```
Here's what seems to be happening:

1. Use gamepad
2. PromptPurchase for a game-pass you already own
3. "Your account has not been charged, press A to close"
4. Press A
5. PurchaseFinished gets fired with ISPURCHASED = true! Even though they didn't actually spend the money on it!
```
Apparently the code was returning true (success) instead of false.