### PR TITLE
Removes duplicate Follow behavior from Classic camera + bug fix

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera/ClassicCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera/ClassicCamera.rbxmx
@@ -1,10 +1,10 @@
 <roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
 	<External>null</External>
 	<External>nil</External>
-	<Item class="ModuleScript" referent="RBX5744EB97A6D34E5AA94E31CE07E5D09D">
+	<Item class="ModuleScript" referent="RBX100DF6F24BA54212B68F05C9E17C8284">
 		<Properties>
 			<Content name="LinkedSource"><null></null></Content>
-			<string name="Name">ClassicCamera</string>
+			<string name="Name">Classic2Camera</string>
 			<ProtectedString name="Source"><![CDATA[local PlayersService = game:GetService('Players')
 local RootCameraCreator = require(script.Parent)
 
@@ -104,8 +104,8 @@ local function CreateClassicCamera()
 						if IsFinite(y) then
 							self.RotateInput = self.RotateInput + Vector2.new(y, 0)
 						end
-					else
-						print("no LastSubjectCFrame")
+					elseif self.LastCameraTransform then
+						--this is so that the camera retains its heading when sitting in a vehicle seat
 						local y = findAngleBetweenXZVectors(self.LastCameraTransform.lookVector, Vector3.new(0,0,-1))
 						if IsFinite(y) then
 							self.RotateInput = self.RotateInput + Vector2.new(y, 0)

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera/ClassicCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera/ClassicCamera.rbxmx
@@ -1,10 +1,10 @@
 <roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
 	<External>null</External>
 	<External>nil</External>
-	<Item class="ModuleScript" referent="RBX100DF6F24BA54212B68F05C9E17C8284">
+	<Item class="ModuleScript" referent="RBX5744EB97A6D34E5AA94E31CE07E5D09D">
 		<Properties>
 			<Content name="LinkedSource"><null></null></Content>
-			<string name="Name">Classic2Camera</string>
+			<string name="Name">ClassicCamera</string>
 			<ProtectedString name="Source"><![CDATA[local PlayersService = game:GetService('Players')
 local RootCameraCreator = require(script.Parent)
 
@@ -104,8 +104,8 @@ local function CreateClassicCamera()
 						if IsFinite(y) then
 							self.RotateInput = self.RotateInput + Vector2.new(y, 0)
 						end
-					elseif self.LastCameraTransform then
-						--this is so that the camera retains its heading when sitting in a vehicle seat
+					else
+						print("no LastSubjectCFrame")
 						local y = findAngleBetweenXZVectors(self.LastCameraTransform.lookVector, Vector3.new(0,0,-1))
 						if IsFinite(y) then
 							self.RotateInput = self.RotateInput + Vector2.new(y, 0)

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera/ClassicCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera/ClassicCamera.rbxmx
@@ -36,11 +36,6 @@ end
 local function CreateClassicCamera()
 	local module = RootCameraCreator()
 	
-	local tweenAcceleration = math.rad(220)
-	local tweenSpeed = math.rad(0)
-	local tweenMaxSpeed = math.rad(250)
-	local timeBeforeAutoRotate = 2
-	
 	local lastThumbstickRotate = nil
 	local numOfSeconds = 0.7
 	local currentSpeed = 0
@@ -72,30 +67,19 @@ local function CreateClassicCamera()
 			-- Cap out the delta to 0.5 so we don't get some crazy things when we re-resume from
 			local delta = math.min(0.5, now - lastUpdate)
 			local angle = 0
-			if not (isInVehicle or isOnASkateboard) then
-				angle = angle + (self.TurningLeft and -120 or 0)
-				angle = angle + (self.TurningRight and 120 or 0)
-			end
+			angle = angle + (self.TurningLeft and -120 or 0)
+			angle = angle + (self.TurningRight and 120 or 0)
 			
 			local gamepadRotation = self:UpdateGamepad()
 			if gamepadRotation ~= Vector2.new(0,0) then
-				userPanningTheCamera = true
 				self.RotateInput = self.RotateInput + gamepadRotation
 			end
 					
 			if angle ~= 0 then
-				userPanningTheCamera = true
 				self.RotateInput = self.RotateInput + Vector2.new(math.rad(angle * delta), 0)
 			end
 		end
-
-		-- Reset tween speed if user is panning
-		if userPanningTheCamera then
-			tweenSpeed = 0
-			module.LastUserPanCamera = tick()
-		end
 		
-		local userRecentlyPannedCamera = now - module.LastUserPanCamera < timeBeforeAutoRotate
 		local subjectPosition = self:GetSubjectPosition()
 		
 		if subjectPosition and player and camera then
@@ -112,36 +96,19 @@ local function CreateClassicCamera()
 				if IsFiniteVector3(offset) then
 					subjectPosition = subjectPosition + offset
 				end
-			else
-				if self.LastCameraTransform and not userPanningTheCamera then
-					local isInFirstPerson = self:IsInFirstPerson()
-					if (isInVehicle or isOnASkateboard) and lastUpdate and humanoid and humanoid.Torso then
-						if isInFirstPerson then
-							if self.LastSubjectCFrame and (isInVehicle or isOnASkateboard) and cameraSubject:IsA('BasePart') then
-								local y = -findAngleBetweenXZVectors(self.LastSubjectCFrame.lookVector, cameraSubject.CFrame.lookVector)
-								if IsFinite(y) then
-									self.RotateInput = self.RotateInput + Vector2.new(y, 0)
-								end
-								tweenSpeed = 0
-							end
-						elseif not userRecentlyPannedCamera then
-							local forwardVector = humanoid.Torso.CFrame.lookVector
-							if isOnASkateboard then
-								forwardVector = cameraSubject.CFrame.lookVector
-							end
-							local timeDelta = (now - lastUpdate)
-							
-							tweenSpeed = clamp(0, tweenMaxSpeed, tweenSpeed + tweenAcceleration * timeDelta)
-	
-							local percent = clamp(0, 1, tweenSpeed * timeDelta)
-							if self:IsInFirstPerson() then
-								percent = 1
-							end
-							
-							local y = findAngleBetweenXZVectors(forwardVector, self:GetCameraLook())
-							if IsFinite(y) and math.abs(y) > 0.0001 then
-								self.RotateInput = self.RotateInput + Vector2.new(y * percent, 0)
-							end
+			end
+			if (isInVehicle or isOnASkateboard) and lastUpdate and humanoid and humanoid.Torso then
+				if (isInVehicle or isOnASkateboard) and cameraSubject:IsA('BasePart') then
+					if self.LastSubjectCFrame then
+						local y = -findAngleBetweenXZVectors(self.LastSubjectCFrame.lookVector, cameraSubject.CFrame.lookVector)
+						if IsFinite(y) then
+							self.RotateInput = self.RotateInput + Vector2.new(y, 0)
+						end
+					else
+						print("no LastSubjectCFrame")
+						local y = findAngleBetweenXZVectors(self.LastCameraTransform.lookVector, Vector3.new(0,0,-1))
+						if IsFinite(y) then
+							self.RotateInput = self.RotateInput + Vector2.new(y, 0)
 						end
 					end
 				end

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera/ClassicCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera/ClassicCamera.rbxmx
@@ -1,7 +1,7 @@
 <roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
 	<External>null</External>
 	<External>nil</External>
-	<Item class="ModuleScript" referent="RBX5744EB97A6D34E5AA94E31CE07E5D09D">
+	<Item class="ModuleScript" referent="RBX100DF6F24BA54212B68F05C9E17C8284">
 		<Properties>
 			<Content name="LinkedSource"><null></null></Content>
 			<string name="Name">ClassicCamera</string>
@@ -104,8 +104,8 @@ local function CreateClassicCamera()
 						if IsFinite(y) then
 							self.RotateInput = self.RotateInput + Vector2.new(y, 0)
 						end
-					else
-						print("no LastSubjectCFrame")
+					elseif self.LastCameraTransform then
+						--this is so that the camera retains its heading when sitting in a vehicle seat
 						local y = findAngleBetweenXZVectors(self.LastCameraTransform.lookVector, Vector3.new(0,0,-1))
 						if IsFinite(y) then
 							self.RotateInput = self.RotateInput + Vector2.new(y, 0)

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/KeyboardMovement.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/KeyboardMovement.rbxmx
@@ -57,6 +57,9 @@ function KeyboardMovement:Enable()
 		return
 	end
 	
+	local ZMovement = 0
+	local XMovement = 0
+	
 	local forwardValue  = 0
 	local backwardValue = 0
 	local leftValue = 0
@@ -64,7 +67,7 @@ function KeyboardMovement:Enable()
 	
 	local updateMovement = function()
 		MasterControl:AddToPlayerMovement(-currentMoveVector)
-		currentMoveVector = Vector3.new(leftValue + rightValue,0,forwardValue + backwardValue)
+		currentMoveVector = Vector3.new(XMovement,0,ZMovement)
 		MasterControl:AddToPlayerMovement(currentMoveVector)
 	end
 	
@@ -79,8 +82,14 @@ function KeyboardMovement:Enable()
 	local moveForwardFunc = function(actionName, inputState, inputObject)
 		if inputState == Enum.UserInputState.Begin then
 			forwardValue = -1
+			ZMovement = -1
 		elseif inputState == Enum.UserInputState.End then
 			forwardValue = 0
+			if backwardValue ~= 0 then
+				ZMovement = 1
+			else
+				ZMovement = 0
+			end
 		end
 		updateMovement()
 	end
@@ -88,8 +97,14 @@ function KeyboardMovement:Enable()
 	local moveBackwardFunc = function(actionName, inputState, inputObject)	
 		if inputState == Enum.UserInputState.Begin then
 			backwardValue = 1
+			ZMovement = 1
 		elseif inputState == Enum.UserInputState.End then
 			backwardValue = 0
+			if forwardValue ~= 0 then
+				ZMovement = -1
+			else
+				ZMovement = 0
+			end
 		end
 		updateMovement()
 	end
@@ -97,8 +112,14 @@ function KeyboardMovement:Enable()
 	local moveLeftFunc = function(actionName, inputState, inputObject)	
 		if inputState == Enum.UserInputState.Begin then
 			leftValue = -1
+			XMovement = -1
 		elseif inputState == Enum.UserInputState.End then
 			leftValue = 0
+			if rightValue ~= 0 then
+				XMovement = 1
+			else
+				XMovement = 0
+			end
 		end
 		updateMovement()
 	end
@@ -106,8 +127,14 @@ function KeyboardMovement:Enable()
 	local moveRightFunc = function(actionName, inputState, inputObject)	
 		if inputState == Enum.UserInputState.Begin then
 			rightValue = 1
+			XMovement = 1
 		elseif inputState == Enum.UserInputState.End then
 			rightValue = 0
+			if leftValue ~= 0 then
+				XMovement = -1
+			else
+				XMovement = 0
+			end
 		end
 		updateMovement()
 	end

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/KeyboardMovement.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/KeyboardMovement.rbxmx
@@ -57,9 +57,6 @@ function KeyboardMovement:Enable()
 		return
 	end
 	
-	local ZMovement = 0
-	local XMovement = 0
-	
 	local forwardValue  = 0
 	local backwardValue = 0
 	local leftValue = 0
@@ -67,7 +64,7 @@ function KeyboardMovement:Enable()
 	
 	local updateMovement = function()
 		MasterControl:AddToPlayerMovement(-currentMoveVector)
-		currentMoveVector = Vector3.new(XMovement,0,ZMovement)
+		currentMoveVector = Vector3.new(leftValue + rightValue,0,forwardValue + backwardValue)
 		MasterControl:AddToPlayerMovement(currentMoveVector)
 	end
 	
@@ -82,14 +79,8 @@ function KeyboardMovement:Enable()
 	local moveForwardFunc = function(actionName, inputState, inputObject)
 		if inputState == Enum.UserInputState.Begin then
 			forwardValue = -1
-			ZMovement = -1
 		elseif inputState == Enum.UserInputState.End then
 			forwardValue = 0
-			if backwardValue ~= 0 then
-				ZMovement = 1
-			else
-				ZMovement = 0
-			end
 		end
 		updateMovement()
 	end
@@ -97,14 +88,8 @@ function KeyboardMovement:Enable()
 	local moveBackwardFunc = function(actionName, inputState, inputObject)	
 		if inputState == Enum.UserInputState.Begin then
 			backwardValue = 1
-			ZMovement = 1
 		elseif inputState == Enum.UserInputState.End then
 			backwardValue = 0
-			if forwardValue ~= 0 then
-				ZMovement = -1
-			else
-				ZMovement = 0
-			end
 		end
 		updateMovement()
 	end
@@ -112,14 +97,8 @@ function KeyboardMovement:Enable()
 	local moveLeftFunc = function(actionName, inputState, inputObject)	
 		if inputState == Enum.UserInputState.Begin then
 			leftValue = -1
-			XMovement = -1
 		elseif inputState == Enum.UserInputState.End then
 			leftValue = 0
-			if rightValue ~= 0 then
-				XMovement = 1
-			else
-				XMovement = 0
-			end
 		end
 		updateMovement()
 	end
@@ -127,14 +106,8 @@ function KeyboardMovement:Enable()
 	local moveRightFunc = function(actionName, inputState, inputObject)	
 		if inputState == Enum.UserInputState.Begin then
 			rightValue = 1
-			XMovement = 1
 		elseif inputState == Enum.UserInputState.End then
 			rightValue = 0
-			if leftValue ~= 0 then
-				XMovement = -1
-			else
-				XMovement = 0
-			end
 		end
 		updateMovement()
 	end


### PR DESCRIPTION
The classic camera uses follow camera behavior when sitting in vehicle seats, which is a very annoying behavior and works in very few games. The camera behavior is changed to the behavior before the player scripts update, which is much easier to use and works in far more games.

A video demonstrates the differences:

https://www.youtube.com/watch?v=PXrL4SyUZRA

A number of games benefited greatly from the camera as it was before the player scripts update: you could look around your vehicle and look at your vehicle at your leisure. The player scripts update has made using VehicleSeats and Skateboards very stressful and frustrating on Roblox, because the update assumed that the only thing VehicleSeats would ever to is to go forwards. This update makes the camera much easier to use and much less frustrating.