### PR TITLE
Report menu and camera fixes

### DIFF
--- a/CoreScriptsRoot/Modules/BackpackScript.lua
+++ b/CoreScriptsRoot/Modules/BackpackScript.lua
@@ -58,6 +58,8 @@ local SEARCH_BACKGROUND_FADE = 0.15
 
 local DOUBLE_CLICK_TIME = 0.5
 
+local CONFIGURED_LOADOUT_GRACE_PERIOD = 0.5
+
 -----------------
 --| Variables |--
 -----------------
@@ -114,12 +116,27 @@ local HotkeyStrings = {} -- Used for eating/releasing hotkeys
 local CharConns = {} -- Holds character connections to be cleared later
 local TopBarEnabled = false
 local GamepadEnabled = false -- determines if our gui needs to be gamepad friendly
+local GridIsOpen = false
 
 local lastEquippedSlot = nil
+
+local UserConfiguration = {}
+
+local CharacterSpawnedAtTime = tick()
 
 -----------------
 --| Functions |--
 -----------------
+
+local function RefreshUserConfiguration()
+	UserConfiguration = {}
+
+	for i, slot in pairs(Slots) do
+		if slot.Tool then
+			UserConfiguration[slot.Tool.Name] = slot.Index
+		end
+	end
+end
 
 local function NewGui(className, objectName)
 	local newGui = Instance.new(className)
@@ -141,6 +158,10 @@ local function NewGui(className, objectName)
 		end
 	end
 	return newGui
+end
+
+local function IsSlotOnHotbar(index)
+	return index <= HOTBAR_SLOTS
 end
 
 local function FindLowestEmpty()
@@ -208,7 +229,7 @@ local function EquipNewTool(tool) --NOTE: HopperBin
 end
 
 local function IsEquipped(tool)
-	return tool and ((tool:IsA('HopperBin') and tool.Active) or tool.Parent == Character) --NOTE: HopperBin
+	return not not (tool and ((tool:IsA('HopperBin') and tool.Active) or tool.Parent == Character)) --NOTE: HopperBin
 end
 
 local function MakeSlot(parent, index)
@@ -390,7 +411,7 @@ local function MakeSlot(parent, index)
 		end
 	end
 
-	function slot:Swap(targetSlot) --NOTE: This slot (self) must not be empty!
+	function slot:Swap(targetSlot)
 		local myTool, otherTool = self.Tool, targetSlot.Tool
 		self:Clear()
 		if otherTool then -- (Target slot might be empty)
@@ -401,6 +422,10 @@ local function MakeSlot(parent, index)
 			targetSlot:Fill(myTool)
 		else
 			targetSlot:Clear()
+		end
+
+		if targetSlot.Tool ~= nil and targetSlot:IsOnHotBar() and targetSlot:IsEquipped() == false then
+			targetSlot:Select()
 		end
 	end
 
@@ -439,6 +464,21 @@ local function MakeSlot(parent, index)
 		return hits
 	end
 
+	function slot:IsOnHotBar()
+		return IsSlotOnHotbar(slot.Index)
+	end
+
+	function slot:Select()
+		local tool = slot.Tool
+		if tool then
+			if slot:IsEquipped() then --NOTE: HopperBin
+				UnequipAllTools()
+			elseif tool.Parent == Backpack then
+				EquipNewTool(tool)
+			end
+		end
+	end
+
 	-- Slot Init Logic --
 
 	SlotFrame = NewGui('TextButton', index)
@@ -466,7 +506,7 @@ local function MakeSlot(parent, index)
 
 	slot:Reposition()
 
-	if index <= HOTBAR_SLOTS then -- Hotbar-Specific Slot Stuff
+	if slot:IsOnHotBar() then -- Hotbar-Specific Slot Stuff
 		-- ToolTip stuff
 		ToolTip = NewGui('TextLabel', 'ToolTip')
 		ToolTip.TextWrapped = false
@@ -482,20 +522,8 @@ local function MakeSlot(parent, index)
 		end)
 		SlotFrame.MouseLeave:connect(function() ToolTip.Visible = false end)
 
-		-- Slot select logic, activated by clicking or pressing hotkey
-		function slot:Select()
-			local tool = slot.Tool
-			if tool then
-				if IsEquipped(tool) then --NOTE: HopperBin
-					UnequipAllTools()
-				elseif tool.Parent == Backpack then
-					EquipNewTool(tool)
-				end
-			end
-		end
-
 		function slot:MoveToInventory()
-			if slot.Index <= HOTBAR_SLOTS then -- From a Hotbar slot
+			if slot:IsOnHotBar() then -- From a Hotbar slot
 				local tool = slot.Tool
 				self:Clear() --NOTE: Order matters here
 				local newSlot = MakeSlot(ScrollingFrame)
@@ -507,6 +535,8 @@ local function MakeSlot(parent, index)
 				if ResultsIndices then
 					newSlot.Frame.Visible = false
 				end
+
+				RefreshUserConfiguration()
 			end
 		end
 
@@ -602,16 +632,40 @@ local function MakeSlot(parent, index)
 
 			-- Check where we were dropped
 			if CheckBounds(InventoryFrame, x, y) then
-				if slot.Index <= HOTBAR_SLOTS then
+				if slot:IsOnHotBar() then
 					slot:MoveToInventory()
+				else
+					local closest, closestDistance
+
+					for i = HOTBAR_SLOTS+1, #Slots do
+						local otherSlot = Slots[i]
+						local distance = GetOffset(otherSlot.Frame, Vector2.new(x, y))
+						if closest == nil or distance < closestDistance then
+							closest, closestDistance = otherSlot, distance
+						end
+					end
+
+					if closest ~= nil and closest ~= slot then
+						slot:Swap(closest)
+
+						RefreshUserConfiguration()
+					end
 				end
 				-- Check for double clicking on an inventory slot, to move into empty hotbar slot
 				if slot.Index > HOTBAR_SLOTS and now - lastUpTime < DOUBLE_CLICK_TIME then
-					if LowestEmptySlot then
+					local targetSlot = LowestEmptySlot
+
+					if targetSlot then
 						local myTool = slot.Tool
 						slot:Clear()
-						LowestEmptySlot:Fill(myTool)
+						targetSlot:Fill(myTool)
 						slot:Delete()
+
+						if targetSlot:IsEquipped() == false then
+							targetSlot:Select()
+						end
+
+						RefreshUserConfiguration()
 					end
 					now = 0 -- Resets the timer
 				end
@@ -627,7 +681,7 @@ local function MakeSlot(parent, index)
 				local closestSlot = closest[2]
 				if closestSlot ~= slot then
 					slot:Swap(closestSlot)
-					if slot.Index > HOTBAR_SLOTS then
+					if not slot:IsOnHotBar() then
 						local tool = slot.Tool
 						if not tool then -- Clean up after ourselves if we're an inventory slot that's now empty
 							slot:Delete()
@@ -641,6 +695,8 @@ local function MakeSlot(parent, index)
 							end
 						end
 					end
+
+					RefreshUserConfiguration()
 				end
 			else
 				-- local tool = slot.Tool
@@ -663,6 +719,150 @@ local function MakeSlot(parent, index)
 	return slot
 end
 
+local function AppendNewSlot()
+	local index = #Slots + 1
+
+	local slot = MakeSlot(ScrollingFrame, index)
+
+	return slot, index
+end
+
+local function GetFirstEmptySlot()
+	-- Always returns Slot, SlotIndex
+
+	if LowestEmptySlot ~= nil then
+		return LowestEmptySlot, LowestEmptySlot.Index
+	else
+		return AppendNewSlot()
+	end
+end
+
+local function InsertNewSlot(index)
+	-- Not actually inserting a slot since slots can't move.
+	-- Actually appending a slot and then shifting every relevant tool one slot to the right (up in the array)
+
+	-- Append the new slot
+	local newSlot, newIndex = GetFirstEmptySlot()
+
+	-- Make sure we aren't trying to insert past the length of the backpack
+	if index > newIndex then
+		index = newIndex
+	end
+
+	-- Perform the right-shift.  This is technically a swap operation but since our appended slot is empty it will behave like a shift.
+	for checkIndex = newIndex, index, -1 do
+		local thisSlot = Slots[checkIndex]
+		local nextSlot = Slots[checkIndex+1]
+
+		if nextSlot ~= nil then
+			thisSlot:Swap(nextSlot)
+		end
+	end
+
+	-- Return the "inserted" slot, which is now empty because the appended slot's emptiness was handed down the chain
+	return Slots[index]
+end
+
+local function GetConfiguredToolSlotIndex(toolName)
+	-- Returns the slot index that the user has placed the tool
+	-- If too much time has passed since the player spawned, return nil
+
+	if tick() - CharacterSpawnedAtTime > CONFIGURED_LOADOUT_GRACE_PERIOD then
+		return nil
+	end
+
+	local savedIndex = UserConfiguration[toolName]
+
+	-- Quick check for first tool
+	if next(Slots) == nil then
+		return 1
+	end
+
+	-- Return the last position if it doesn't exist in configuration
+	if savedIndex == nil then
+		if LowestEmptySlot == nil then
+			return #Slots + 1
+		else
+			return LowestEmptySlot.Index
+		end
+	end
+
+	-- Find currently loaded slots
+	local slotIndexes = {}
+
+	for i, slot in pairs(Slots) do
+		if slot.Tool then
+			slotIndexes[slot.Tool.Name] = slot.Index
+		end
+	end
+
+	-- Find closest currently-loaded tools that are below amd above the saved configuration
+	local closestBelow, closestBelowIndex, closestAbove, closestAboveIndex
+
+	for i, otherSlot in pairs(Slots) do
+		local otherTool = otherSlot.Tool
+
+		if otherTool ~= nil then
+			local otherName = otherTool.Name
+			local otherSavedIndex = UserConfiguration[otherName]
+
+			if otherSavedIndex ~= nil then
+				if otherSavedIndex < savedIndex then -- Other tool was saved below this tool
+					if closestBelow == nil or savedIndex - closestBelowIndex > savedIndex - otherSavedIndex then
+						closestBelow, closestBelowIndex = otherSlot, otherSavedIndex
+
+						if closestBelowIndex == savedIndex - 1 then
+							break
+						end
+					end
+				elseif otherSavedIndex > savedIndex then -- Other tool was saved above this tool
+					if closestAbove == nil or closestAboveIndex - savedIndex > otherSavedIndex - savedIndex then
+						closestAbove, closestAboveIndex = otherSlot, otherSavedIndex
+
+						if closestAboveIndex == savedIndex + 1 then
+							closestBelow = nil -- Could get the wrong idea if we break the loop and closestBelow is set to something that is not the correct value.
+							break
+						end
+					end
+				end
+			end
+		end
+	end
+
+	-- Return the closestIndex + 1 to put it on top
+	if closestBelow ~= nil then
+		return closestBelow.Index + 1
+	elseif closestAbove ~= nil then
+		return closestAbove.Index
+	else
+		return nil
+	end
+end
+
+local function AddToolSlot(tool)
+	-- Finds or creates a slot for a tool then adds the tool to it.
+
+	local slot
+	local slotIndex = GetConfiguredToolSlotIndex(tool.Name)
+
+	-- Get the slot
+	if slotIndex == nil then
+		slot, slotIndex = GetFirstEmptySlot()
+	else
+		if Slots[slotIndex] == nil then
+			slot, slotIndex = AppendNewSlot()
+		else
+			slot = InsertNewSlot(slotIndex)
+		end
+	end
+
+	-- Add the tool
+	slot:Fill(tool)
+
+	-- Return
+	return slot
+end
+
 local function OnChildAdded(child) -- To Character or Backpack
 	if not child:IsA('Tool') and not child:IsA('HopperBin') then --NOTE: HopperBin
 		if child:IsA('Humanoid') and child.Parent == Character then
@@ -682,24 +882,18 @@ local function OnChildAdded(child) -- To Character or Backpack
 		if starterGear then
 			if starterGear:FindFirstChild(tool.Name) then
 				StarterToolFound = true
-				local slot = LowestEmptySlot or MakeSlot(ScrollingFrame)
-				for i = slot.Index, 1, -1 do
-					local curr = Slots[i] -- An empty slot, because above
-					local pIndex = i - 1
-					if pIndex > 0 then
-						local prev = Slots[pIndex] -- Guaranteed to be full, because above
-						prev:Swap(curr)
-					else
-						curr:Fill(tool)
-					end
-				end
+
+				local slot = AddToolSlot(tool)
+
 				-- Have to manually unequip a possibly equipped tool
 				for _, child in pairs(Character:GetChildren()) do
 					if child:IsA('Tool') and child ~= tool then
 						child.Parent = Backpack
 					end
 				end
+
 				AdjustHotbarFrames()
+
 				return -- We're done here
 			end
 		end
@@ -710,8 +904,8 @@ local function OnChildAdded(child) -- To Character or Backpack
 	if slot then
 		slot:UpdateEquipView()
 	else -- New! Put into lowest hotbar slot or new inventory slot
-		slot = LowestEmptySlot or MakeSlot(ScrollingFrame)
-		slot:Fill(tool)
+		local slot = AddToolSlot(tool)
+
 		if slot.Index <= HOTBAR_SLOTS and not InventoryFrame.Visible then
 			AdjustHotbarFrames()
 		end
@@ -752,6 +946,8 @@ local function OnChildRemoved(child) -- From Character or Backpack
 end
 
 local function OnCharacterAdded(character)
+	CharacterSpawnedAtTime = tick()
+
 	-- First, clean up any old slots
 	for i = #Slots, 1, -1 do
 		local slot = Slots[i]
@@ -1008,7 +1204,11 @@ function changeSlot(slot)
 			slot.Frame.BorderSizePixel = 3
 		end
 	else
-		slot:Select()
+		if slot:IsOnHotBar() then
+			if slot:IsEquipped() == false or GridIsOpen == false then
+				slot:Select()
+			end
+		end
 	end
 end
 
@@ -1438,6 +1638,8 @@ do -- Make the Inventory expand/collapse arrow (unless TopBar)
 		if SettingsHub.Instance.Visible then
 			SettingsHub:SetVisibility(false)
 		end
+
+		GridIsOpen = InventoryFrame.Visible
 	end
 	HotkeyFns[ARROW_HOTKEY] = openClose
 	BackpackScript.OpenClose = openClose -- Exposed

--- a/CoreScriptsRoot/Modules/Settings/Pages/ReportAbuseMenu.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/ReportAbuseMenu.lua
@@ -165,7 +165,7 @@ local function Initialize()
 			submitText.ZIndex = 1
 		end
 
-		local function areFieldsCompleted()
+		local function fieldsCompleted()
 			-- Returns: Bool completed
 			-- Tells you if the fields required for submission have been filled out
 
@@ -193,7 +193,7 @@ local function Initialize()
 			-- Returns: Bool active
 			-- Activates/deactivates the submit button based on current state
 
-			local active = areFieldsCompleted()
+			local active = fieldsCompleted()
 
 			if active then
 				makeSubmitButtonActive()
@@ -229,41 +229,41 @@ local function Initialize()
 		end
 
 		local function onReportSubmitted()
-			if areFieldsCompleted() then
-				local abuseReason = nil
-				if this.GameOrPlayerMode.CurrentIndex == 2 then
-					abuseReason = ABUSE_TYPES_PLAYER[this.TypeOfAbuseMode.CurrentIndex]
+			if not fieldsCompleted() then return end
+			
+			local abuseReason = nil
+			if this.GameOrPlayerMode.CurrentIndex == 2 then
+				abuseReason = ABUSE_TYPES_PLAYER[this.TypeOfAbuseMode.CurrentIndex]
 
-					local currentAbusingPlayer = this:GetPlayerFromIndex(this.WhichPlayerMode.CurrentIndex)
-					if currentAbusingPlayer and abuseReason then
-						spawn(function()
-							game.Players:ReportAbuse(currentAbusingPlayer, abuseReason, this.AbuseDescription.Selection.Text)
-						end)
-					end
-				else
-					abuseReason = ABUSE_TYPES_GAME[this.TypeOfAbuseMode.CurrentIndex]
-					if abuseReason then
-						spawn(function()
-							game.Players:ReportAbuse(nil, abuseReason, this.AbuseDescription.Selection.Text)
-						end)
-					end
+				local currentAbusingPlayer = this:GetPlayerFromIndex(this.WhichPlayerMode.CurrentIndex)
+				if currentAbusingPlayer and abuseReason then
+					spawn(function()
+						game.Players:ReportAbuse(currentAbusingPlayer, abuseReason, this.AbuseDescription.Selection.Text)
+					end)
 				end
-
+			else
+				abuseReason = ABUSE_TYPES_GAME[this.TypeOfAbuseMode.CurrentIndex]
 				if abuseReason then
-					local alertText = "Thanks for your report! Our moderators will review the chat logs and evaluate what happened."
-
-					if abuseReason == 'Cheating/Exploiting' then
-						alertText = "Thanks for your report! We've recorded your report for evaluation."
-					elseif abuseReason == 'Inappropriate Username' then
-						alertText = "Thanks for your report! Our moderators will evaluate the username."
-					elseif abuseReason == "Bad Model or Script" or  abuseReason == "Inappropriate Content" or abuseReason == "Offsite Link" or abuseReason == "Offsite Links" then
-						alertText = "Thanks for your report! Our moderators will review the place and make a determination."
-					end
-
-					utility:ShowAlert(alertText, "Ok", this.HubRef, cleanupReportAbuseMenu)
-
-					this.LastSelectedObject = nil
+					spawn(function()
+						game.Players:ReportAbuse(nil, abuseReason, this.AbuseDescription.Selection.Text)
+					end)
 				end
+			end
+
+			if abuseReason then
+				local alertText = "Thanks for your report! Our moderators will review the chat logs and evaluate what happened."
+
+				if abuseReason == 'Cheating/Exploiting' then
+					alertText = "Thanks for your report! We've recorded your report for evaluation."
+				elseif abuseReason == 'Inappropriate Username' then
+					alertText = "Thanks for your report! Our moderators will evaluate the username."
+				elseif abuseReason == "Bad Model or Script" or  abuseReason == "Inappropriate Content" or abuseReason == "Offsite Link" or abuseReason == "Offsite Links" then
+					alertText = "Thanks for your report! Our moderators will review the place and make a determination."
+				end
+
+				utility:ShowAlert(alertText, "Ok", this.HubRef, cleanupReportAbuseMenu)
+
+				this.LastSelectedObject = nil
 			end
 		end
 

--- a/CoreScriptsRoot/Modules/Settings/Pages/ReportAbuseMenu.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/ReportAbuseMenu.lua
@@ -73,12 +73,12 @@ local function Initialize()
 		this.WhichPlayerMode:UpdateDropDownList(playerNames)
 		
 		if index == 1 then
-			this.GameOrPlayerMode:SetSelectionIndex(1)
+			this.GameOrPlayerMode:SetSelectionIndex(1, true)
 			this.TypeOfAbuseMode:UpdateDropDownList(ABUSE_TYPES_GAME)
 		end
 
-		this.WhichPlayerMode:SetInteractable(index > 1 and this.GameOrPlayerMode.CurrentIndex ~= 1)
-		this.GameOrPlayerMode:SetInteractable(index > 1)
+		this.WhichPlayerMode:SetInteractable(index >= 1 and this.GameOrPlayerMode.CurrentIndex ~= 1)
+		this.GameOrPlayerMode:SetInteractable(index >= 1)
 	end
 
 	------ TAB CUSTOMIZATION -------
@@ -165,6 +165,45 @@ local function Initialize()
 			submitText.ZIndex = 1
 		end
 
+		local function areFieldsCompleted()
+			-- Returns: Bool completed
+			-- Tells you if the fields required for submission have been filled out
+
+			local completed = false
+
+			local gameOrPlayerIndex = this.GameOrPlayerMode.CurrentIndex
+			local selectedPlayerIndex = this.WhichPlayerMode:GetSelectedIndex()
+			local selectedAbuseTypeIndex = this.TypeOfAbuseMode:GetSelectedIndex()
+			
+			if gameOrPlayerIndex == 1 then -- Game type abuse
+				local abuseTypeIsSelected = selectedAbuseTypeIndex ~= nil and selectedAbuseTypeIndex > 0
+
+				completed = abuseTypeIsSelected
+			elseif gameOrPlayerIndex == 2 then -- Player type abuse
+				local playerIsSelected = selectedPlayerIndex ~= nil and selectedPlayerIndex > 0
+				local abuseTypeIsSelected = selectedAbuseTypeIndex ~= nil and selectedAbuseTypeIndex > 0
+
+				completed = playerIsSelected and abuseTypeIsSelected
+			end
+
+			return completed
+		end
+
+		local function updateSubmitButtonState()
+			-- Returns: Bool active
+			-- Activates/deactivates the submit button based on current state
+
+			local active = areFieldsCompleted()
+
+			if active then
+				makeSubmitButtonActive()
+			else
+				makeSubmitButtonInactive()
+			end
+
+			return active
+		end
+
 		local function updateAbuseDropDown()
 			this.WhichPlayerMode:ResetSelectionIndex()
 			this.TypeOfAbuseMode:ResetSelectionIndex()
@@ -190,39 +229,41 @@ local function Initialize()
 		end
 
 		local function onReportSubmitted()
-			local abuseReason = nil
-			if this.GameOrPlayerMode.CurrentIndex == 2 then
-				abuseReason = ABUSE_TYPES_PLAYER[this.TypeOfAbuseMode.CurrentIndex]
+			if areFieldsCompleted() then
+				local abuseReason = nil
+				if this.GameOrPlayerMode.CurrentIndex == 2 then
+					abuseReason = ABUSE_TYPES_PLAYER[this.TypeOfAbuseMode.CurrentIndex]
 
-				local currentAbusingPlayer = this:GetPlayerFromIndex(this.WhichPlayerMode.CurrentIndex)
-				if currentAbusingPlayer and abuseReason then
-					spawn(function()
-						game.Players:ReportAbuse(currentAbusingPlayer, abuseReason, this.AbuseDescription.Selection.Text)
-					end)
+					local currentAbusingPlayer = this:GetPlayerFromIndex(this.WhichPlayerMode.CurrentIndex)
+					if currentAbusingPlayer and abuseReason then
+						spawn(function()
+							game.Players:ReportAbuse(currentAbusingPlayer, abuseReason, this.AbuseDescription.Selection.Text)
+						end)
+					end
+				else
+					abuseReason = ABUSE_TYPES_GAME[this.TypeOfAbuseMode.CurrentIndex]
+					if abuseReason then
+						spawn(function()
+							game.Players:ReportAbuse(nil, abuseReason, this.AbuseDescription.Selection.Text)
+						end)
+					end
 				end
-			else
-				abuseReason = ABUSE_TYPES_GAME[this.TypeOfAbuseMode.CurrentIndex]
+
 				if abuseReason then
-					spawn(function()
-						game.Players:ReportAbuse(nil, abuseReason, this.AbuseDescription.Selection.Text)
-					end)
+					local alertText = "Thanks for your report! Our moderators will review the chat logs and evaluate what happened."
+
+					if abuseReason == 'Cheating/Exploiting' then
+						alertText = "Thanks for your report! We've recorded your report for evaluation."
+					elseif abuseReason == 'Inappropriate Username' then
+						alertText = "Thanks for your report! Our moderators will evaluate the username."
+					elseif abuseReason == "Bad Model or Script" or  abuseReason == "Inappropriate Content" or abuseReason == "Offsite Link" or abuseReason == "Offsite Links" then
+						alertText = "Thanks for your report! Our moderators will review the place and make a determination."
+					end
+
+					utility:ShowAlert(alertText, "Ok", this.HubRef, cleanupReportAbuseMenu)
+
+					this.LastSelectedObject = nil
 				end
-			end
-
-			if abuseReason then
-				local alertText = "Thanks for your report! Our moderators will review the chat logs and evaluate what happened."
-
-				if abuseReason == 'Cheating/Exploiting' then
-					alertText = "Thanks for your report! We've recorded your report for evaluation."
-				elseif abuseReason == 'Inappropriate Username' then
-					alertText = "Thanks for your report! Our moderators will evaluate the username."
-				elseif abuseReason == "Bad Model or Script" or  abuseReason == "Inappropriate Content" or abuseReason == "Offsite Link" or abuseReason == "Offsite Links" then
-					alertText = "Thanks for your report! Our moderators will review the place and make a determination."
-				end
-
-				utility:ShowAlert(alertText, "Ok", this.HubRef, cleanupReportAbuseMenu)
-
-				this.LastSelectedObject = nil
 			end
 		end
 
@@ -232,32 +273,12 @@ local function Initialize()
 		else
 			submitButton.Position = UDim2.new(1,-194,1,5)
 		end
-		submitButton.Selectable = false
-		submitButton.ZIndex = 1
-		submitText.ZIndex = 1
 		submitButton.Parent = this.AbuseDescription.Selection
+		updateSubmitButtonState()
 
-		local function playerSelectionChanged(newIndex)
-			if newIndex ~= nil and this.TypeOfAbuseMode:GetSelectedIndex() ~= nil then
-				makeSubmitButtonActive()
-			else
-				makeSubmitButtonInactive()
-			end
-		end
-		this.WhichPlayerMode.IndexChanged:connect(playerSelectionChanged)
+		this.WhichPlayerMode.IndexChanged:connect(updateSubmitButtonState)
 
-		local function typeOfAbuseChanged(newIndex)
-			if newIndex ~= nil then
-				if this.GameOrPlayerMode.CurrentIndex == 1 or this.WhichPlayerMode:GetSelectedIndex() ~= nil then
-					makeSubmitButtonActive()
-				else
-					makeSubmitButtonInactive()
-				end
-			else
-				makeSubmitButtonInactive()
-			end
-		end
-		this.TypeOfAbuseMode.IndexChanged:connect(typeOfAbuseChanged)
+		this.TypeOfAbuseMode.IndexChanged:connect(updateSubmitButtonState)
 
 		this.GameOrPlayerMode.IndexChanged:connect(updateAbuseDropDown)
 

--- a/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
@@ -963,10 +963,6 @@ local function CreateSettingsHub()
 
 			local noOpFunc = function() end
 			ContextActionService:BindCoreAction("RbxSettingsHubStopCharacter", noOpFunc, false,
-												 Enum.PlayerActions.CharacterForward, 
-												 Enum.PlayerActions.CharacterBackward, 
-												 Enum.PlayerActions.CharacterLeft,
-												 Enum.PlayerActions.CharacterRight,
 												 Enum.PlayerActions.CharacterJump, 
 												 Enum.KeyCode.LeftShift,
 												 Enum.KeyCode.RightShift,

--- a/CoreScriptsRoot/Modules/Settings/Utility.lua
+++ b/CoreScriptsRoot/Modules/Settings/Utility.lua
@@ -921,15 +921,15 @@ local function CreateSelector(selectionStringTable, startPosition)
 			ZIndex = 2
 		}
 		autoSelectButton.MouseButton1Click:connect(function()
-			if interactable then
-				local newIndex = this.CurrentIndex + 1
-				if newIndex > #this.Selections then
-					newIndex = 1
-				end
-				this:SetSelectionIndex(newIndex)
-				if usesSelectedObject() then
-					GuiService.SelectedCoreObject = this.SelectorFrame
-				end
+			if not interactable then return end
+
+			local newIndex = this.CurrentIndex + 1
+			if newIndex > #this.Selections then
+				newIndex = 1
+			end
+			this:SetSelectionIndex(newIndex)
+			if usesSelectedObject() then
+				GuiService.SelectedCoreObject = this.SelectorFrame
 			end
 		end)
 		isAutoSelectButton[autoSelectButton] = true

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript.rbxmx
@@ -149,11 +149,21 @@ end
 
 local function SetEnabledCamera(newCamera)
 	if EnabledCamera ~= newCamera then
+		local zoomLevel = nil
+
 		if EnabledCamera then
+			zoomLevel = EnabledCamera:GetCameraZoom()
+
 			EnabledCamera:SetEnabled(false)
 		end
+
 		EnabledCamera = newCamera
+
 		if EnabledCamera then
+			if zoomLevel then
+				EnabledCamera:ZoomCamera(zoomLevel)
+			end
+			
 			EnabledCamera:SetEnabled(true)
 		end
 	end

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
@@ -209,7 +209,7 @@ local function CreateCamera()
 				UserInputService.MouseBehavior = Enum.MouseBehavior.LockCurrentPosition
 			else
 				UserInputService.MouseBehavior = Enum.MouseBehavior.Default
-			end	
+			end
 		end
 	end
 
@@ -225,9 +225,12 @@ local function CreateCamera()
 
 		isFirstPerson = self:GetCameraZoom() < 2
 
-		ShiftLockController:SetIsInFirstPerson(isFirstPerson)
-		-- set mouse behavior
-		self:UpdateMouseBehavior()
+		if this.Enabled then
+			ShiftLockController:SetIsInFirstPerson(isFirstPerson)
+			-- set mouse behavior
+			self:UpdateMouseBehavior()
+		end
+
 		return self:GetCameraZoom()
 	end
 
@@ -738,10 +741,8 @@ local function CreateCamera()
 
 	local function OnPlayerAdded(player)
 		player.Changed:connect(function(prop)
-			if this.Enabled then
-				if prop == "CameraMode" or prop == "CameraMaxZoomDistance" or prop == "CameraMinZoomDistance" then
-					 this:ZoomCameraFixedBy(0)
-				end
+			if prop == "CameraMode" or prop == "CameraMaxZoomDistance" or prop == "CameraMinZoomDistance" then
+				 this:ZoomCameraFixedBy(0)
 			end
 		end)
 		

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
@@ -124,6 +124,12 @@ local function setJumpModule(isEnabled)
 	end
 end
 
+local function evaluateShowJumpModule()
+	local show = IsTouchDevice and isJumpEnabled and MasterControl:IsHumanoidJumpEnabled()
+	
+	setJumpModule(show)
+end
+
 local function setClickToMove()
 	if DevMovementMode == Enum.DevTouchMovementMode.ClickToMove or DevMovementMode == Enum.DevComputerMovementMode.ClickToMove or
 		UserMovementMode == Enum.ComputerMovementMode.ClickToMove or UserMovementMode == Enum.TouchMovementMode.ClickToMove then
@@ -289,11 +295,7 @@ if IsTouchDevice then
 			if ClickToMoveTouchControls == ControlModules.Thumbpad or ClickToMoveTouchControls == ControlModules.Thumbstick or
 				ClickToMoveTouchControls == ControlModules.Default then
 				--
-				if isOn then
-					TouchJumpModule:Enable()
-				else
-					TouchJumpModule:Disable()
-				end
+				evaluateShowJumpModule()
 			end
 		end
 	end)
@@ -315,7 +317,7 @@ if UserInputService.GamepadEnabled then
 	if CurrentControlModule and IsTouchDevice then
 		CurrentControlModule:Disable()
 	end
-	if isJumpEnabled and IsTouchDevice then TouchJumpModule:Disable() end
+	evaluateShowJumpModule()
 
 	ControlModules.Gamepad:Enable()
 end
@@ -326,7 +328,7 @@ UserInputService.GamepadDisconnected:connect(function(gamepadEnum)
 	if CurrentControlModule and IsTouchDevice then
 			CurrentControlModule:Enable()
 	end
-	if isJumpEnabled and IsTouchDevice then TouchJumpModule:Enable() end
+	evaluateShowJumpModule()
 	
 	ControlModules.Gamepad:Disable()
 end)
@@ -337,10 +339,14 @@ UserInputService.GamepadConnected:connect(function(gamepadEnum)
 	if CurrentControlModule and IsTouchDevice then
 		CurrentControlModule:Disable()
 	end
-	if isJumpEnabled and IsTouchDevice then TouchJumpModule:Disable() end
+	evaluateShowJumpModule()
 	
 	ControlModules.Gamepad:Enable()
 end)
+MasterControl.ControlStepped:connect(function() -- Must be done constantly because there is no Humanoid.StateEnabledChanged event
+	evaluateShowJumpModule()
+end)
+
 
 
 
@@ -454,10 +460,13 @@ function getTouchModule()
 end
 
 function setJumpModule(isEnabled)
-	if not isEnabled then
-		TouchJumpModule:Disable()
-	elseif ControlState.Current == ControlModules.Touch then
-		TouchJumpModule:Enable()
+	if isEnabled ~= TouchJumpModule.Enabled then
+		if not isEnabled then
+			TouchJumpModule:Disable()
+		elseif CurrentControlModule == ControlModules.Thumbpad or CurrentControlModule == ControlModules.Thumbstick or CurrentControlModule == ControlModules.Default then
+			--
+			TouchJumpModule:Enable()
+		end
 	end
 end
 
@@ -472,6 +481,12 @@ function setClickToMove()
 		ClickToMoveTouchControls:Disable()
 		ClickToMoveTouchControls = nil
 	end
+end
+
+local function evaluateShowJumpModule()
+	local show = IsTouchDevice and isJumpEnabled and MasterControl:IsHumanoidJumpEnabled()
+	
+	setJumpModule(show)
 end
 
 ControlModules.Touch = {}
@@ -490,7 +505,7 @@ function ControlModules.Touch:Enable()
 		
 		newModuleToEnable:Enable()
 		
-		if isJumpEnabled then TouchJumpModule:Enable() end
+		ControlModules.Touch:EvaluateJumpButton()
 	end
 end
 function ControlModules.Touch:Disable()
@@ -501,10 +516,24 @@ function ControlModules.Touch:Disable()
 		newModuleToDisable == ThumbpadModule then
 			newModuleToDisable:Disable()
 			setJumpModule(false)
-			TouchJumpModule:Disable()
+			ControlModules.Touch:EvaluateJumpButton()
 	end
 end
+function ControlModules.Touch:ShowJumpButton(doShow)
+	if doShow ~= TouchJumpModule.Enabled then
+		if doShow == true then
+			TouchJumpModule:Enable()
+		elseif doShow == false then
+			TouchJumpModule:Disable()
+		end
+	end
+end
+function ControlModules.Touch:EvaluateJumpButton()
+	local doesCurrentControlModuleUseJumpButton = currentModule == ThumbstickModule or currentModule == ThumbpadModule
+	local doShow = IsTouchDevice and isJumpEnabled and isModalEnabled and doesCurrentControlModuleUseJumpButton and MasterControl:IsHumanoidJumpEnabled()
 
+	ControlModules.Touch:ShowJumpButton(doShow)
+end
 
 local function getKeyboardModule()
 	-- NOTE: Click to move still uses keyboard. Leaving cases in case this ever changes.
@@ -684,6 +713,10 @@ UserInputService.GamepadConnected:connect(function(gamepadEnum)
 	if gamepadEnum ~= Enum.UserInputType.Gamepad1 then return end
 	
 	ControlState:SwitchTo(ControlModules.Gamepad)
+end)
+
+MasterControl.ControlStepped:connect(function() -- Must be done constantly because there is no Humanoid.StateEnabledChanged event
+	ControlModules.Touch:EvaluateJumpButton()
 end)
 
 end -- end of control script flag switch]]></ProtectedString>

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
@@ -115,12 +115,14 @@ end
 
 --[[ Local Functions ]]--
 local function setJumpModule(isEnabled)
-	if not isEnabled then
-		TouchJumpModule:Disable()
-	elseif CurrentControlModule == ControlModules.Thumbpad or CurrentControlModule == ControlModules.Thumbstick or
-		CurrentControlModule == ControlModules.Default then
-		--
-		TouchJumpModule:Enable()
+	if TouchJumpModule ~= nil then
+		if not isEnabled then
+			TouchJumpModule:Disable()
+		elseif CurrentControlModule == ControlModules.Thumbpad or CurrentControlModule == ControlModules.Thumbstick or
+			CurrentControlModule == ControlModules.Default then
+			--
+			TouchJumpModule:Enable()
+		end
 	end
 end
 

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl.rbxmx
@@ -51,6 +51,9 @@ local function getHumanoid()
 end
 
 --[[ Public API ]]--
+local ControlStepped = Instance.new'BindableEvent'
+MasterControl.ControlStepped = ControlStepped.Event
+
 function MasterControl:Init()
 	
 	local renderStepFunc = function()
@@ -62,8 +65,10 @@ function MasterControl:Init()
 				humanoid.Jump = isJumping
 			end
 			
-			moveFunc(LocalPlayer, moveValue, true)	
+			moveFunc(LocalPlayer, moveValue, true)
 		end
+		
+		ControlStepped:Fire()
 	end
 	
 	local success = pcall(function() RunService:BindToRenderStep("MasterControlStep", Enum.RenderPriority.Input.Value, renderStepFunc) end)
@@ -105,6 +110,21 @@ function MasterControl:DoJump()
 		humanoid.Jump = true
 	end
 end
+
+function MasterControl:IsHumanoidJumpEnabled()
+	local humanoid = getHumanoid()
+	local enabled = true
+	
+	if humanoid then
+		if humanoid.JumpPower == 0 then
+			enabled = false
+		elseif humanoid:GetStateEnabled(Enum.HumanoidStateType.Jumping) == false then
+			enabled = false
+		end
+	end
+	
+	return enabled
+end	
 
 return MasterControl
 ]]></ProtectedString>

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
@@ -123,7 +123,9 @@ function Thumbstick:Create(parentFrame)
 				0, pos.y - ThumbstickFrame.AbsoluteSize.y/2 - offset.y)
 		else
 			length = math.min(length, maxLength)
-			relativePosition = relativePosition.unit * length
+			if relativePosition.magnitude > 0 then
+				relativePosition = relativePosition.unit * length
+			end
 		end
 		StickImage.Position = UDim2.new(0, relativePosition.x + StickImage.AbsoluteSize.x/2, 0, relativePosition.y + StickImage.AbsoluteSize.y/2)
 	end

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
@@ -13,7 +13,9 @@
 
 local Players = game:GetService('Players')
 
-local TouchJump = {}
+local TouchJump = {
+	Enabled = false
+}
 
 local MasterControl = require(script.Parent)
 
@@ -31,11 +33,13 @@ local TOUCH_CONTROL_SHEET = "rbxasset://textures/ui/TouchControlsSheet.png"
 --[[ Public API ]]--
 function TouchJump:Enable()
 	JumpButton.Visible = true
+	TouchJump.Enabled = true
 end
 
 function TouchJump:Disable()
 	JumpButton.Visible = false
 	OnInputEnded()
+	TouchJump.Enabled = false
 end
 
 function TouchJump:Create(parentFrame)


### PR DESCRIPTION
- Can’t report players without filling out required fields
- Dropdown open buttons no longer animate when not allowed
- Fixed weird tween effect with the “game or player” when switching to
  the report page
- Disabled selectors can no longer be used by clicking them in the
  center
- Camera zoom level persists between modes, preventing players from
  getting into third person when first person is forced
