### PR TITLE
Update HealthScript.lua

### DIFF
--- a/CoreScriptsRoot/CoreScripts/HealthScript.lua
+++ b/CoreScriptsRoot/CoreScripts/HealthScript.lua
@@ -6,12 +6,9 @@
 
 ---------------------------------------------------------------------
 -- Initialize/Variables
-while not game do
-	wait(1/60)
-end
-while not game:GetService("Players") do
-	wait(1/60)
-end
+
+repeat wait() until game
+repeat wait() until game:GetService("Players").LocalPlayer
 
 local useCoreHealthBar = false
 local success = pcall(function() useCoreHealthBar = game:GetService("Players"):GetUseCoreScriptHealthBar() end)
@@ -41,10 +38,6 @@ local hurtOverlayImage = "http://www.roblox.com/asset/?id=34854607"
 
 game:GetService("ContentProvider"):Preload(greenBarImage)
 game:GetService("ContentProvider"):Preload(hurtOverlayImage)
-
-while not game:GetService("Players").LocalPlayer do
-	wait(1/60)
-end
 
 ---------------------------------------------------------------------
 -- Functions


### PR DESCRIPTION
Changed the way the script waits for game.Players.LocalPlayer.
Removed a wait until game:GetService("Players"), as it is contradicting to have a wait for players and a wait for game.Players.LocalPlayer. When you could just have a wait until game.Players.LocalPlayer and accomplish the same thing.