### PR TITLE
Make input at topbar work when hidden

### DIFF
--- a/CoreScriptsRoot/CoreScripts/Topbar.lua
+++ b/CoreScriptsRoot/CoreScripts/Topbar.lua
@@ -180,6 +180,10 @@ local function CreateTopBar()
 		end
 	end
 
+	function this:SetActive(active)
+		topbarContainer.Active = active	
+	end
+
 	function this:GetInstance()
 		return topbarContainer
 	end
@@ -1234,6 +1238,7 @@ function topBarEnabledChanged()
 	topbarEnabledChangedEvent:Fire(topbarEnabled)
 	TopBar:UpdateBackgroundTransparency()
 	CheckShiftLockMode()
+	TopBar:SetActive(topbarEnabled)
 	for _, enumItem in pairs(Enum.CoreGuiType:GetEnumItems()) do
 		-- The All enum will be false if any of the coreguis are false
 		-- therefore by force updating it we are clobbering the previous sets


### PR DESCRIPTION
A quick and easy change that makes (regular PlayerGui) GuiObjects accept input.
They'll only receive input when the topbar is hidden using SetCore.
This allows people to create their own interactive menubar.

The settingsbutton still has Active set to true, so buttons under it don't accept input.
This change only has effect on stuff under the topbar where nothing is to begin with.