### PR TITLE
Fix Robux Products for High Priced Assets

### DIFF
--- a/CoreScriptsRoot/CoreScripts/PurchasePromptScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/PurchasePromptScript2.lua
@@ -643,7 +643,7 @@ local function getRobuxProduct(amountNeeded, isBCMember)
 		end
 	end
 
-	return productArray[1]
+	return nil
 end
 
 local function getRobuxProductToBuyItem(amountNeeded)

--- a/CoreScriptsRoot/CoreScripts/PurchasePromptScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/PurchasePromptScript2.lua
@@ -703,6 +703,7 @@ local function setBuyMoreRobuxDialog(playerBalance)
 		--
 		if not ThirdPartyProductName then
 			descriptionText = "This item cost more ROBUX than you can purchase. Please visit www.roblox.com to purchase more ROBUX."
+			purchaseState = PURCHASE_STATE.FAILED
 			setButtonsVisible(OkButton)
 		else
 			local remainder = playerBalanceInt + productCost - PurchaseData.CurrencyAmount


### PR DESCRIPTION
Currently, if there exists no robux product of sufficient size for a given asset, getRobuxProduct returns the robux product of the smallest amount, rather than returning nil(meaning no product of sufficient size exists). This resolves said issue.