### PR TITLE
Fix service references

### DIFF
--- a/CoreScriptsRoot/Modules/PlayerlistModule.lua
+++ b/CoreScriptsRoot/Modules/PlayerlistModule.lua
@@ -1503,6 +1503,14 @@ local function resizePlayerList()
 	clampCanvasPosition()
 end
 
+function isControlKeyDown()
+	return UserInputService:IsKeyDown(Enum.KeyCode.LeftAlt) 
+		or UserInputService:IsKeyDown(Enum.KeyCode.RightAlt)
+		or UserInputService:IsKeyDown(Enum.KeyCode.LeftControl)
+		or UserInputService:IsKeyDown(Enum.KeyCode.RightAlt)
+		or UserInputService:IsKeyDown(Enum.KeyCode.LeftMeta)
+end
+
 RobloxGui.Changed:connect(function(property)
 	if property == 'AbsoluteSize' then
 		spawn(function()	-- must spawn because F11 delays when abs size is set
@@ -1661,6 +1669,7 @@ Playerlist.ToggleVisibility = function(name, inputState, inputObject)
 	if inputState and inputState ~= Enum.UserInputState.Begin then return end
 	if IsSmallScreenDevice then return end
 	if not playerlistCoreGuiEnabled then return end
+	if isControlKeyDown() then return end
 
 	isOpen = not isOpen
 

--- a/CoreScriptsRoot/Modules/PlayerlistModule.lua
+++ b/CoreScriptsRoot/Modules/PlayerlistModule.lua
@@ -1503,14 +1503,6 @@ local function resizePlayerList()
 	clampCanvasPosition()
 end
 
-function isControlKeyDown()
-	return UserInputService:IsKeyDown(Enum.KeyCode.LeftAlt) 
-		or UserInputService:IsKeyDown(Enum.KeyCode.RightAlt)
-		or UserInputService:IsKeyDown(Enum.KeyCode.LeftControl)
-		or UserInputService:IsKeyDown(Enum.KeyCode.RightAlt)
-		or UserInputService:IsKeyDown(Enum.KeyCode.LeftMeta)
-end
-
 RobloxGui.Changed:connect(function(property)
 	if property == 'AbsoluteSize' then
 		spawn(function()	-- must spawn because F11 delays when abs size is set
@@ -1669,7 +1661,6 @@ Playerlist.ToggleVisibility = function(name, inputState, inputObject)
 	if inputState and inputState ~= Enum.UserInputState.Begin then return end
 	if IsSmallScreenDevice then return end
 	if not playerlistCoreGuiEnabled then return end
-	if isControlKeyDown() then return end
 
 	isOpen = not isOpen
 

--- a/CoreScriptsRoot/Modules/Settings/Pages/Players.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/Players.lua
@@ -12,6 +12,7 @@ local PlayersService = game:GetService('Players')
 local HttpService = game:GetService('HttpService')
 local HttpRbxApiService = game:GetService('HttpRbxApiService')
 local UserInputService = game:GetService('UserInputService')
+local Players = game:GetService("Players")
 local Settings = UserSettings()
 local GameSettings = Settings.GameSettings
 
@@ -215,7 +216,7 @@ local function Initialize()
 
 	local existingPlayerLabels = {}
 	this.Displayed.Event:connect(function(switchedFromGamepadInput)
-		local sortedPlayers = game.Players:GetPlayers()
+		local sortedPlayers = Players:GetPlayers()
 		table.sort(sortedPlayers,function(item1,item2)
 			return item1.Name < item2.Name
 		end)

--- a/CoreScriptsRoot/Modules/Settings/Pages/Players.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/Players.lua
@@ -12,7 +12,6 @@ local PlayersService = game:GetService('Players')
 local HttpService = game:GetService('HttpService')
 local HttpRbxApiService = game:GetService('HttpRbxApiService')
 local UserInputService = game:GetService('UserInputService')
-local Players = game:GetService("Players")
 local Settings = UserSettings()
 local GameSettings = Settings.GameSettings
 
@@ -216,7 +215,7 @@ local function Initialize()
 
 	local existingPlayerLabels = {}
 	this.Displayed.Event:connect(function(switchedFromGamepadInput)
-		local sortedPlayers = Players:GetPlayers()
+		local sortedPlayers = PlayersService:GetPlayers()
 		table.sort(sortedPlayers,function(item1,item2)
 			return item1.Name < item2.Name
 		end)

--- a/CoreScriptsRoot/Modules/Settings/Pages/ReportAbuseMenu.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/ReportAbuseMenu.lua
@@ -9,7 +9,7 @@
 local CoreGui = game:GetService("CoreGui")
 local RobloxGui = CoreGui:WaitForChild("RobloxGui")
 local GuiService = game:GetService("GuiService")
-local Players = game:GetService("Players")
+local PlayersService = game:GetService("Players")
 
 ----------- UTILITIES --------------
 local utility = require(RobloxGui.Modules.Settings.Utility)
@@ -60,7 +60,7 @@ local function Initialize()
 		playerNames = {}
 	    	nameToRbxPlayer = {}
 
-		local players = Players:GetPlayers()
+		local players = PlayersService:GetPlayers()
 		local index = 1
 		for i = 1, #players do
 			local player = players[i]

--- a/CoreScriptsRoot/Modules/Settings/Pages/ReportAbuseMenu.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/ReportAbuseMenu.lua
@@ -64,7 +64,7 @@ local function Initialize()
 		local index = 1
 		for i = 1, #players do
 			local player = players[i]
-			if player ~= Players.LocalPlayer and player.UserId > 0 then
+			if player ~= PlayersService.LocalPlayer and player.UserId > 0 then
 				playerNames[index] = player.Name
 				nameToRbxPlayer[player.Name] = player
 				index = index + 1

--- a/CoreScriptsRoot/Modules/Settings/Pages/ReportAbuseMenu.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/ReportAbuseMenu.lua
@@ -9,6 +9,7 @@
 local CoreGui = game:GetService("CoreGui")
 local RobloxGui = CoreGui:WaitForChild("RobloxGui")
 local GuiService = game:GetService("GuiService")
+local Players = game:GetService("Players")
 
 ----------- UTILITIES --------------
 local utility = require(RobloxGui.Modules.Settings.Utility)
@@ -57,13 +58,13 @@ local function Initialize()
 
 	function this:UpdatePlayerDropDown()
 		playerNames = {}
-	    nameToRbxPlayer = {}
+	    	nameToRbxPlayer = {}
 
-		local players = game.Players:GetChildren()
+		local players = Players:GetPlayers()
 		local index = 1
 		for i = 1, #players do
 			local player = players[i]
-			if player:IsA('Player') and player ~= game:GetService("Players").LocalPlayer and player.UserId > 0 then
+			if player ~= Players.LocalPlayer and player.UserId > 0 then
 				playerNames[index] = player.Name
 				nameToRbxPlayer[player.Name] = player
 				index = index + 1

--- a/CoreScriptsRoot/Modules/Settings/Pages/ResetCharacter.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/ResetCharacter.lua
@@ -13,6 +13,7 @@ local CoreGui = game:GetService("CoreGui")
 local ContextActionService = game:GetService("ContextActionService")
 local RobloxGui = CoreGui:WaitForChild("RobloxGui")
 local GuiService = game:GetService("GuiService")
+local Players = game:GetService("Players")
 
 ----------- UTILITIES --------------
 local utility = require(RobloxGui.Modules.Settings.Utility)
@@ -73,7 +74,7 @@ local function Initialize()
 
 	------ Init -------
 	local resetCharFunc = function()
-		local player = game.Players.LocalPlayer
+		local player = Players.LocalPlayer
 		if player then
 			local character = player.Character
 			if character then

--- a/CoreScriptsRoot/Modules/Settings/Pages/ResetCharacter.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/ResetCharacter.lua
@@ -13,7 +13,7 @@ local CoreGui = game:GetService("CoreGui")
 local ContextActionService = game:GetService("ContextActionService")
 local RobloxGui = CoreGui:WaitForChild("RobloxGui")
 local GuiService = game:GetService("GuiService")
-local Players = game:GetService("Players")
+local PlayersService = game:GetService("Players")
 
 ----------- UTILITIES --------------
 local utility = require(RobloxGui.Modules.Settings.Utility)
@@ -74,7 +74,7 @@ local function Initialize()
 
 	------ Init -------
 	local resetCharFunc = function()
-		local player = Players.LocalPlayer
+		local player = PlayersService.LocalPlayer
 		if player then
 			local character = player.Character
 			if character then


### PR DESCRIPTION
Use game:GetService to prevent breaking when services are renamed.