### PR TITLE
VR Camera Control Improvements

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript.rbxmx
@@ -139,13 +139,16 @@ local function Update()
 	if EnabledCamera then
 		EnabledCamera:Update()
 		EnabledCamera:ApplyCameraCFrame()
-		EnabledCamera:ApplyVROffset()
 	end
 	if EnabledOcclusion then
 		EnabledOcclusion:Update()
 	end
 	if shouldUsePlayerScriptsCamera() then
 		TransparencyController:Update()
+	end
+
+	if EnabledCamera then
+		EnabledCamera:ApplyVROffset()
 	end
 end
 

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
@@ -9,9 +9,9 @@
 local PlayersService = game:GetService('Players')
 local UserInputService = game:GetService('UserInputService')
 
---NoVR will be false if the platform does not have the VREnabled property, because indexing it will throw an error.
+--NoVRAPI will be false if the platform does not have the VREnabled property, because indexing it will throw an error.
 local success = pcall(function() local _ = UserInputService.VREnabled end)
-local NoVR = not success
+local NoVRAPI = not success
 
 local CameraScript = script.Parent
 local ShiftLockController = require(CameraScript:WaitForChild('ShiftLockController'))
@@ -305,7 +305,7 @@ local function CreateCamera()
 	end
 
 	function this:ApplyVROffset()
-		if NoVR then return end
+		if NoVRAPI then return end
 		if UserInputService.VREnabled and workspace.CurrentCamera and workspace.CurrentCamera.CameraType ~= Enum.CameraType.Scriptable then
 			workspace.CurrentCamera.CoordinateFrame = workspace.CurrentCamera.CoordinateFrame * UserInputService.UserHeadCFrame
 		

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
@@ -9,8 +9,8 @@
 local PlayersService = game:GetService('Players')
 local UserInputService = game:GetService('UserInputService')
 
---NoVR will be false if the platform does not have the IsVREnabled property, because indexing it will throw an error.
-local success = pcall(function() local _ = UserInputService.IsVREnabled end)
+--NoVR will be false if the platform does not have the VREnabled property, because indexing it will throw an error.
+local success = pcall(function() local _ = UserInputService.VREnabled end)
 local NoVR = not success
 
 local CameraScript = script.Parent
@@ -19,6 +19,7 @@ local ShiftLockController = require(CameraScript:WaitForChild('ShiftLockControll
 local Settings = UserSettings()
 local GameSettings = Settings.GameSettings
 
+local VR_PITCH_FRACTION = 0.5
 
 local function clamp(low, high, num)
 	if low <= high then
@@ -58,6 +59,9 @@ end
 
 local MIN_Y = math.rad(-80)
 local MAX_Y = math.rad(80)
+
+local VR_MIN_Y = math.rad(-30)
+local VR_MAX_Y = math.rad(30)
 
 local TOUCH_SENSITIVTY = Vector2.new(math.pi*2.25, math.pi*2)
 local MOUSE_SENSITIVITY = Vector2.new(math.pi*4, math.pi*1.9)
@@ -196,8 +200,15 @@ local function CreateCamera()
 	end
 
 	function this:RotateCamera(startLook, xyRotateVector)
+		local maxY = MAX_Y
+		local minY = MIN_Y
+		if UserInputService.VREnabled then
+			maxY = VR_MAX_Y
+			minY = VR_MIN_Y
+		end
+
 		local startVertical = math.asin(startLook.y)
-		local yTheta = clamp(-MAX_Y + startVertical, -MIN_Y + startVertical, xyRotateVector.y)
+		local yTheta = clamp(-maxY + startVertical, -minY + startVertical, xyRotateVector.y)
 		return self:RotateVector(startLook, Vector2.new(xyRotateVector.x, yTheta))
 	end
 
@@ -295,8 +306,11 @@ local function CreateCamera()
 
 	function this:ApplyVROffset()
 		if NoVR then return end
-		if UserInputService.IsVREnabled and workspace.CurrentCamera and workspace.CurrentCamera.CameraType ~= Enum.CameraType.Scriptable then
+		if UserInputService.VREnabled and workspace.CurrentCamera and workspace.CurrentCamera.CameraType ~= Enum.CameraType.Scriptable then
 			workspace.CurrentCamera.CoordinateFrame = workspace.CurrentCamera.CoordinateFrame * UserInputService.UserHeadCFrame
+		
+			local inclination = math.asin(module.cframe.lookVector.y)
+			workspace.CurrentCamera.CoordinateFrame = workspace.CurrentCamera.CoordinateFrame * CFrame.Angles(-inclination * (1 - VR_PITCH_FRACTION), 0, 0)
 		end
 	end
 

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera/FollowCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera/FollowCamera.rbxmx
@@ -9,9 +9,9 @@
 local UserInputService = game:GetService('UserInputService')
 local RootCameraCreator = require(script.Parent)
 
---NoVR will be false if the platform does not have the IsVREnabled property, because indexing it will throw an error.
+--NoVRAPI will be false if the platform does not have the IsVREnabled property, because indexing it will throw an error.
 local success = pcall(function() local _ = UserInputService.IsVREnabled end)
-local NoVR = not success
+local NoVRAPI = not success
 
 local UP_VECTOR = Vector3.new(0, 1, 0)
 local XZ_VECTOR = Vector3.new(1,0,1)
@@ -139,7 +139,7 @@ local function CreateFollowCamera()
 								self.RotateInput = self.RotateInput + Vector2.new(y * percent, 0)
 							end
 						end
-					elseif not (isInFirstPerson or userRecentlyPannedCamera) and not NoVR and not UserInputService.IsVREnabled then
+					elseif not (isInFirstPerson or userRecentlyPannedCamera) and not NoVRAPI and not UserInputService.IsVREnabled then
 						local lastVec = -(self.LastCameraTransform.p - subjectPosition)
 						local y = findAngleBetweenXZVectors(lastVec, self:GetCameraLook())
 						-- Check for NaNs

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera/FollowCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera/FollowCamera.rbxmx
@@ -9,8 +9,8 @@
 local UserInputService = game:GetService('UserInputService')
 local RootCameraCreator = require(script.Parent)
 
---NoVRAPI will be false if the platform does not have the IsVREnabled property, because indexing it will throw an error.
-local success = pcall(function() local _ = UserInputService.IsVREnabled end)
+--NoVRAPI will be false if the platform does not have the VREnabled property, because indexing it will throw an error.
+local success = pcall(function() local _ = UserInputService.VREnabled end)
 local NoVRAPI = not success
 
 local UP_VECTOR = Vector3.new(0, 1, 0)
@@ -139,7 +139,7 @@ local function CreateFollowCamera()
 								self.RotateInput = self.RotateInput + Vector2.new(y * percent, 0)
 							end
 						end
-					elseif not (isInFirstPerson or userRecentlyPannedCamera) and not NoVRAPI and not UserInputService.IsVREnabled then
+					elseif not (isInFirstPerson or userRecentlyPannedCamera) and not NoVRAPI and not UserInputService.VREnabled then
 						local lastVec = -(self.LastCameraTransform.p - subjectPosition)
 						local y = findAngleBetweenXZVectors(lastVec, self:GetCameraLook())
 						-- Check for NaNs


### PR DESCRIPTION
- Applying VR offset *after* occlusion check eliminates weird behavior when clipping camera into parts
- Changed IsVREnabled references to new VREnabled
- Changed pitch min/max to 30 degrees instead of 80, goes with following change
- Negated pitching of the camera after VR offset by a variable fraction, set to 50% right now.