### PR TITLE
Allow free models to bypass ThirdPartySales filtering

### DIFF
--- a/CoreScriptsRoot/CoreScripts/PurchasePromptScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/PurchasePromptScript2.lua
@@ -1035,6 +1035,7 @@ local function canPurchase(disableUpsell)
 	end
 
 	-- check if owned by player; dev products are not owned
+	local isRestrictedThirdParty = false
 	if not IsPurchasingConsumable then
 		local success, doesOwnItem = doesPlayerOwnItem()
 		if not success then
@@ -1057,13 +1058,17 @@ local function canPurchase(disableUpsell)
 			local ProductCreator = tonumber(PurchaseData.ProductInfo["Creator"]["Id"])
 			local RobloxCreator = 1
 			if ProductCreator ~= game.CreatorId and ProductCreator ~= RobloxCreator then
-				onPurchaseFailed(PURCHASE_FAILED.THIRD_PARTY_DISABLED)
-				return false    
+				isRestrictedThirdParty = true
 			end
 		end
 	end
 
 	local isFree = isFreeItem()
+
+	if not isFree and isRestrictedThirdParty then
+		onPurchaseFailed(PURCHASE_FAILED.THIRD_PARTY_DISABLED)
+		return false    
+	end
 
 	local playerBalance = getPlayerBalance()
 	if not playerBalance then


### PR DESCRIPTION
This will allow models with a "take one" option.