### PR TITLE
Fixed problem with PopperCam & NPC CameraSubjects

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/PopperCam.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/PopperCam.rbxmx
@@ -153,7 +153,7 @@ function PopperCam:Update()
 		local ignoreList = {}
 		
 		local cameraSubject = Camera.CameraSubject
-		if cameraSubject:IsA("Humanoid") then
+		if cameraSubject and cameraSubject:IsA("Humanoid") then
 			local character = cameraSubject.Parent
 			if character and character:IsA("Model") then
 				table.insert(ignoreList,character)

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/PopperCam.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/PopperCam.rbxmx
@@ -151,6 +151,15 @@ function PopperCam:Update()
 		local cameraFrontPoint = cameraCFrame.p + (cameraCFrame.lookVector * NEAR_CLIP_PLANE_OFFSET)
 		local screenSize = Camera.ViewportSize
 		local ignoreList = {}
+		
+		local cameraSubject = Camera.CameraSubject
+		if cameraSubject:IsA("Humanoid") then
+			local character = cameraSubject.Parent
+			if character and character:IsA("Model") then
+				table.insert(ignoreList,character)
+			end
+		end
+		
 		for _, character in pairs(PlayerCharacters) do
 			table.insert(ignoreList, character)
 		end


### PR DESCRIPTION
There was a bug with the PopperCam, where it would keep popping if the CameraSubject was set to an NPC, rather than the character of a Player.
Repro with the current version:
* Insert an NPC with a Humanoid into the Workspace.
* Set the CameraSubject to the NPC's Humanoid
* The PopperCam does not ignore the NPC, and will continuously keep popping forward.

This pull-request fixes the bug.