### PR TITLE
Make leave button change color on mouse events

### DIFF
--- a/CoreScriptsRoot/Modules/Settings/Pages/LeaveGame.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/LeaveGame.lua
@@ -88,6 +88,16 @@ local function Initialize()
 	else
 		this.LeaveGameButton.Position = UDim2.new(0.5, -buttonSize.X.Offset - buttonSpacing, 1, -30)
 	end
+	this.LeaveGameButton.InputBegan:connect(function(inputObject)
+		if inputObject.UserInputType == Enum.UserInputType.Touch then
+			this.LeaveGameButton.ImageColor3 = Color3.new(0.6,0.6,0.6)
+		end
+	end)
+	this.LeaveGameButton.InputEnded:connect(function(inputObject)
+		if inputObject.UserInputType == Enum.UserInputType.Touch then
+			this.LeaveGameButton.ImageColor3 = Color3.new(1,1,1)
+		end
+	end)
 	this.LeaveGameButton.Parent = leaveGameText
 
 


### PR DESCRIPTION
Currently the leave button doesn't look like it works on touch, because
the color doesn't change when you press the button, and it might take a
long time (up to 10 seconds) to actually close the game.  This is not a
great user experience, so this helps a bit by letting you know you
actually clicked the button