### PR TITLE
Update Chat.lua - Improper whitespace filtering

### DIFF
--- a/CoreScriptsRoot/Modules/Chat.lua
+++ b/CoreScriptsRoot/Modules/Chat.lua
@@ -341,15 +341,15 @@ do
 		return TextSizeCache[text][font][sizeBounds][fontSize]
 	end
 
-	local PRINTABLE_CHARS = '[^' .. string.char(32) .. '-' ..  string.char(126) .. ']'
-	local WHITESPACE_CHARS = '(' .. string.rep('%s', 7) .. ')%s+'
+	local UNPRINTABLE_CHARS = '[^' .. string.char(32) .. '-' ..  string.char(126) .. ']'
+	local WHITESPACE_CHARS = '%s+'
 	function Util.FilterUnprintableCharacters(str)
 		if not GetLuaChatFilteringFlag() then
 			return str
 		end
 
-		local result = str:gsub(PRINTABLE_CHARS, '');
-		result = str:gsub(WHITESPACE_CHARS, '%1');
+		local result = str:gsub(UNPRINTABLE_CHARS, '');
+		result = str:gsub(WHITESPACE_CHARS, string.char(32));
 		return result
 	end
 end


### PR DESCRIPTION
Update to `Util.FilterUnprintableCharacters` function - Changing whitespace filter from defective match to all whitespace characters.

This will change all whitespace characters into a single space, preventing both whitespace spam (multiple spaces) and invalid whitespace characters (such as newlines and tabs)

For clarity, also renaming the local variable `PRINTABLE_CHARS` to a more fitting `UNPRINTABLE_CHARS` as the assigned string pattern matches all characters *besides* the printable ones.