### PR TITLE
Fixed Dialogs not showing if Bubble Chat is disabled

### DIFF
--- a/CoreScriptsRoot/CoreScripts/BubbleChat.lua
+++ b/CoreScriptsRoot/CoreScripts/BubbleChat.lua
@@ -604,8 +604,6 @@ local function createChatOutput()
 	end
 
 	function this:OnGameChatMessage(origin, message, color)
-		if not this:BubbleChatEnabled() then return end
-
 		local localPlayer = PlayersService.LocalPlayer
 		local fromOthers = localPlayer ~= nil and (localPlayer.Character ~= origin)
 


### PR DESCRIPTION
There was a problem that was preventing dialogs from being shown if the game does not have bubble chat enabled.

Dialog bubble chats should be shown, regardless if players have bubble chat or not.