### PR TITLE
CLI-11421 Fixed Mobile controls disappearing when character is loaded in.

### DIFF
--- a/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
+++ b/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
@@ -670,15 +670,14 @@ local function setupGamepadControls()
 		end
 	end
 	
+	local loadedConnection
 	local function enableRadialMenu()
 		ContextActionService:BindCoreAction(toggleMenuActionName, doGamepadMenuButton, false, Enum.KeyCode.ButtonStart)
+		loadedConnection:disconnect()
 	end
 	
-	local loadedConnection = game.Loaded:connect(enableRadialMenu)
+	loadedConnection = game.Loaded:connect(enableRadialMenu)
 	StarterGui.CoreGuiChangedSignal:connect(setRadialButtonEnabled)
-	
-	game.Close:wait()
-	loadedConnection:disconnect()
 end
 
 -- hook up gamepad stuff

--- a/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
+++ b/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
@@ -625,9 +625,11 @@ local function setupGamepadControls()
 
 	doGamepadMenuButton = function(name, state, input)
 		if state ~= Enum.UserInputState.Begin then return end
-
-		if not toggleCoreGuiRadial() then
-			unbindAllRadialActions()
+		
+		if game.IsLoaded then
+			if not toggleCoreGuiRadial() then
+				unbindAllRadialActions()
+			end
 		end
 	end
 
@@ -667,9 +669,16 @@ local function setupGamepadControls()
 			setButtonEnabled(button, enabled)
 		end
 	end
+	
+	local function enableRadialMenu()
+		ContextActionService:BindCoreAction(toggleMenuActionName, doGamepadMenuButton, false, Enum.KeyCode.ButtonStart)
+	end
+	
+	local loadedConnection = game.Loaded:connect(enableRadialMenu)
 	StarterGui.CoreGuiChangedSignal:connect(setRadialButtonEnabled)
-
-	ContextActionService:BindCoreAction(toggleMenuActionName, doGamepadMenuButton, false, Enum.KeyCode.ButtonStart)
+	
+	game.Close:wait()
+	loadedConnection:disconnect()
 end
 
 -- hook up gamepad stuff

--- a/CoreScriptsRoot/Modules/PlayerDropDown.lua
+++ b/CoreScriptsRoot/Modules/PlayerDropDown.lua
@@ -215,15 +215,12 @@ local function GetBlockedPlayersAsync()
 			local request = HttpRbxApiService:GetAsync(apiPath)
 			blockList = request and game:GetService('HttpService'):JSONDecode(request)
 		end)
-		if success then
-			if blockList and blockList['success'] == true and blockList['userList'] then
-				local returnList = {}
-				for i, v in pairs(blockList['userList']) do
-					returnList[v] = true
-				end
-				return returnList
-			else
+		if blockList and blockList['success'] == true and blockList['userList'] then
+			local returnList = {}
+			for i, v in pairs(blockList['userList']) do
+				returnList[v] = true
 			end
+			return returnList
 		end
 	end
 	return {}

--- a/CoreScriptsRoot/Modules/PlayerDropDown.lua
+++ b/CoreScriptsRoot/Modules/PlayerDropDown.lua
@@ -215,8 +215,15 @@ local function GetBlockedPlayersAsync()
 			local request = HttpRbxApiService:GetAsync(apiPath)
 			blockList = request and game:GetService('HttpService'):JSONDecode(request)
 		end)
-		if blockList and blockList['success'] == true and blockList['userList'] then
-			return blockList['userList']
+		if success then
+			if blockList and blockList['success'] == true and blockList['userList'] then
+				local returnList = {}
+				for i, v in pairs(blockList['userList']) do
+					returnList[v] = true
+				end
+				return returnList
+			else
+			end
 		end
 	end
 	return {}
@@ -227,7 +234,7 @@ spawn(function()
 end)
 
 local function isBlocked(userId)
-	if (BlockedList[userId] ~= nil and BlockedList[userId] == true) then
+	if (BlockedList[userId]) then
 		return true
 	end
 	return false

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
@@ -312,10 +312,10 @@ end)
 -- On touch devices we need to recreate the guis on character load.
 local lastControlState = nil
 LocalPlayer.CharacterAdded:connect(function(character)
-	-- this code was taken from CharacterRemoving and placed into here to accommodate for CharacterAutoLoads being disabled
-	lastControlState = ControlState.Current
-	ControlState:SwitchTo(nil)
-	--
+	if ControlState.Current then -- only do this if it wasn't done through CharacterRemoving
+		lastControlState = ControlState.Current
+		ControlState:SwitchTo(nil)
+	end
 	
 	if UserInputService.TouchEnabled then
 		createTouchGuiContainer()
@@ -324,6 +324,11 @@ LocalPlayer.CharacterAdded:connect(function(character)
 	if ControlState.Current == nil then
 		ControlState:SwitchTo(lastControlState)
 	end
+end)
+
+LocalPlayer.CharacterRemoving:connect(function()
+	lastControlState = ControlState.Current
+	ControlState:SwitchTo(nil)
 end)
 	
 UserInputService.Changed:connect(function(property)

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
@@ -312,6 +312,11 @@ end)
 -- On touch devices we need to recreate the guis on character load.
 local lastControlState = nil
 LocalPlayer.CharacterAdded:connect(function(character)
+	-- this code was taken from CharacterRemoving and placed into here to accommodate for CharacterAutoLoads being disabled
+	lastControlState = ControlState.Current
+	ControlState:SwitchTo(nil)
+	--
+	
 	if UserInputService.TouchEnabled then
 		createTouchGuiContainer()
 	end
@@ -319,11 +324,6 @@ LocalPlayer.CharacterAdded:connect(function(character)
 	if ControlState.Current == nil then
 		ControlState:SwitchTo(lastControlState)
 	end
-end)
-
-LocalPlayer.CharacterRemoving:connect(function(character)
-	lastControlState = ControlState.Current
-	ControlState:SwitchTo(nil)
 end)
 	
 UserInputService.Changed:connect(function(property)


### PR DESCRIPTION
Because CharacterRemoving is never called when Players.CharacterAutoLoads = false on the initial load in, Control State would never be set to nil, causing the UI to not enable when the character loaded in. This fix moves the code from the CharacterRemoving event connection to the CharacterAdded one, which has no effect on the code other than accommodating CharacterAutoLoads.