### PR TITLE
CLI-10871 fixed radial menu toggle (2)

### DIFF
--- a/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
+++ b/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
@@ -676,7 +676,16 @@ local function setupGamepadControls()
 		loadedConnection:disconnect()
 	end
 	
-	loadedConnection = game.Loaded:connect(enableRadialMenu)
+	loadedConnection = game.Players.PlayerAdded:connect(function(plr) 
+		if game.Players.LocalPlayer and plr == game.Players.LocalPlayer then
+			enableRadialMenu()
+		end
+	end)
+	
+	if game.Players.LocalPlayer then
+		enableRadialMenu()
+	end
+	
 	StarterGui.CoreGuiChangedSignal:connect(setRadialButtonEnabled)
 end
 


### PR DESCRIPTION
Additional edit to fix the enableRadialMenu function not firing if the event had already fired, and made it so that instead of being tied to the game.Loaded event, it instead uses LocalPlayer.