### PR TITLE
CLI-10725 Buttons should be smaller in the UI for mobile

### DIFF
--- a/CoreScriptsRoot/CoreScripts/ContextActionTouch.lua
+++ b/CoreScriptsRoot/CoreScripts/ContextActionTouch.lua
@@ -194,6 +194,9 @@ function createButton( actionName, functionInfoTable )
 
 	if buttonScreenGui and buttonScreenGui.Parent == nil then
 		buttonScreenGui.Parent = localPlayer.PlayerGui
+		if not buttonFrame.Parent then
+			buttonFrame.Parent = buttonScreenGui
+		end
 	end
 end
 

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
@@ -56,9 +56,9 @@ function TouchJump:Create(parentFrame)
 	JumpButton.ImageRectOffset = Vector2.new(176, 222)
 	JumpButton.ImageRectSize = Vector2.new(174, 174)
 	JumpButton.Size = UDim2.new(0, jumpButtonSize, 0, jumpButtonSize)
-	JumpButton.Position = isSmallScreen and UDim2.new(1, -origJumpButtonSize - 10, 1, -origJumpButtonSize) or
-		UDim2.new(1, -origJumpButtonSize, 1, -origJumpButtonSize * 1.75)
-	
+	JumpButton.Position = isSmallScreen and UDim2.new(1, -(origJumpButtonSize) + 10, 1, -(origJumpButtonSize-(jumpButtonSize/2)) - 20) or
+		UDim2.new(1, -origJumpButtonSize, 1, -origJumpButtonSize * 1.5)
+		
 	local touchObject = nil	
 	JumpButton.InputBegan:connect(function(inputObject)
 		if touchObject or inputObject.UserInputType ~= Enum.UserInputType.Touch then

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
@@ -45,7 +45,8 @@ function TouchJump:Create(parentFrame)
 	end
 	
 	local isSmallScreen = parentFrame.AbsoluteSize.y <= 500
-	local jumpButtonSize = isSmallScreen and 70 or 90
+	local origJumpButtonSize = (isSmallScreen and 70 or 120)
+	local jumpButtonSize = origJumpButtonSize/2
 	
 	JumpButton = Instance.new('ImageButton')
 	JumpButton.Name = "JumpButton"
@@ -55,8 +56,8 @@ function TouchJump:Create(parentFrame)
 	JumpButton.ImageRectOffset = Vector2.new(176, 222)
 	JumpButton.ImageRectSize = Vector2.new(174, 174)
 	JumpButton.Size = UDim2.new(0, jumpButtonSize, 0, jumpButtonSize)
-	JumpButton.Position = isSmallScreen and UDim2.new(1, jumpButtonSize * -2.25, 1, -jumpButtonSize - 20) or
-		UDim2.new(1, jumpButtonSize * -2.75, 1, -jumpButtonSize - 120)
+	JumpButton.Position = isSmallScreen and UDim2.new(1, -origJumpButtonSize - 10, 1, -origJumpButtonSize) or
+		UDim2.new(1, -origJumpButtonSize, 1, -origJumpButtonSize * 1.75)
 	
 	local touchObject = nil	
 	JumpButton.InputBegan:connect(function(inputObject)


### PR DESCRIPTION
Made the mobile Jump and context action buttons the same size as the interior thumbstick button (35x35 pixels on small devices, 45,45 on larger ones) and then positioned them accordingly to have roughly the same position on the other side of the screen.