### PR TITLE
Fix error when sorting non-sortable stats

### DIFF
--- a/CoreScriptsRoot/Modules/PlayerlistModule.lua
+++ b/CoreScriptsRoot/Modules/PlayerlistModule.lua
@@ -348,7 +348,15 @@ local function sortPlayerEntries(a, b)
 	end
 	if not a.PrimaryStat then return false end
 	if not b.PrimaryStat then return true end
-	return a.PrimaryStat > b.PrimaryStat
+	local statA = a.PrimaryStat
+	local statB = b.PrimaryStat
+	statA = tonumber(statA) or statA
+	statB = tonumber(statB) or statB
+	if type(statA) ~= type(statB) then
+		statA = tostring(statA)
+		statB = tostring(statB)
+	end
+	return statA > statB
 end
 
 local function sortLeaderStats(a, b)


### PR DESCRIPTION
As reported here:
http://devforum.roblox.com/t/mixing-numeric-and-string-values-in-one-column-in-leaderstats-causes-corescript-errors/26058
With this new sortPlayerEntries(a,b) it'll be sorted numeric if possible, otherwise stringwise.

Cases where the error currently happens:

* Having a StringValue in one player and an IntValue in another player as primary stat
*(Any combination where the type(value) is different from the 2 values)*
* Having a BoolValue in one or more players as primary stat