### PR TITLE
CLIMOB-2466 Fixed other Movement Modes not working after spawning wit…

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
@@ -155,9 +155,9 @@ ControlModules.Touch.GameSettingsChangedCon = nil
 function ControlModules.Touch:RefreshControlStyle()
 	if ControlModules.Touch.Current then
 		ControlModules.Touch.Current:Disable()
-		setJumpModule(false)
-		TouchJumpModule:Disable()
 	end
+	setJumpModule(false)
+	TouchJumpModule:Disable()
 	ControlModules.Touch:Enable()
 end
 function ControlModules.Touch:DisconnectEvents()

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
@@ -153,10 +153,11 @@ ControlModules.Touch.LocalPlayerChangedCon = nil
 ControlModules.Touch.GameSettingsChangedCon = nil
 
 function ControlModules.Touch:RefreshControlStyle()
-	ControlModules.Touch.Current:Disable()
-	setJumpModule(false)
-	TouchJumpModule:Disable()
-	
+	if ControlModules.Touch.Current then
+		ControlModules.Touch.Current:Disable()
+		setJumpModule(false)
+		TouchJumpModule:Disable()
+	end
 	ControlModules.Touch:Enable()
 end
 function ControlModules.Touch:DisconnectEvents()
@@ -183,22 +184,23 @@ function ControlModules.Touch:Enable()
 		
 		newModuleToEnable:Enable()
 		ControlModules.Touch.Current = newModuleToEnable
-
-		ControlModules.Touch:DisconnectEvents()
-		ControlModules.Touch.LocalPlayerChangedCon = LocalPlayer.Changed:connect(function(property)
-			if property == 'DevTouchMovementMode' then
-				ControlModules.Touch:RefreshControlStyle()
-			end
-		end)		
-		
-		ControlModules.Touch.GameSettingsChangedCon = GameSettings.Changed:connect(function(property)
-			if property == 'TouchMovementMode' then
-				ControlModules.Touch:RefreshControlStyle()
-			end
-		end)
-		
+				
 		if isJumpEnabled then TouchJumpModule:Enable() end
 	end
+	
+	-- This being within the above if statement was causing issues with ClickToMove, which isn't a module within this script.
+	ControlModules.Touch:DisconnectEvents()
+	ControlModules.Touch.LocalPlayerChangedCon = LocalPlayer.Changed:connect(function(property)
+		if property == 'DevTouchMovementMode' then
+			ControlModules.Touch:RefreshControlStyle()
+		end
+	end)
+	
+	ControlModules.Touch.GameSettingsChangedCon = GameSettings.Changed:connect(function(property)
+		if property == 'TouchMovementMode' then
+			ControlModules.Touch:RefreshControlStyle()
+		end
+	end)
 end
 function ControlModules.Touch:Disable()
 	ControlModules.Touch:DisconnectEvents()


### PR DESCRIPTION
…h ClickToMove enabled

Because of how ClickToMove isn't a module of the control script, the necessary code for connecting the movement style changes wasn't running, due to it not getting a module. This fix makes it so that these events are called outside of that if statement. So far this change works fine on my mobile devices; but I'll look into the ClickToMove module and Camera Script to make sure there aren't any unforeseen issues.