### PR TITLE
Keyboard ControlModule refresh when (Dev)ComputerMovementMode changes

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
@@ -239,6 +239,10 @@ local function getKeyboardModule()
 end
 
 ControlModules.Keyboard = {}
+function ControlModules.Keyboard:RefreshControlStyle()
+	ControlModules.Keyboard:Disable()
+	ControlModules.Keyboard:Enable()
+end
 function ControlModules.Keyboard:Enable()
 	DevMovementMode = LocalPlayer.DevComputerMovementMode
 	IsUserChoice = DevMovementMode == Enum.DevComputerMovementMode.UserChoice
@@ -247,13 +251,35 @@ function ControlModules.Keyboard:Enable()
 	end
 		
 	local newModuleToEnable = getKeyboardModule()
-	if newModuleToEnable then	
-		if newModuleToEnable then
-			newModuleToEnable:Enable()
+	if newModuleToEnable then
+		newModuleToEnable:Enable()
+	end
+	
+	ControlModules.Keyboard:DisconnectEvents()
+	ControlModules.Keyboard.LocalPlayerChangedCon = LocalPlayer.Changed:connect(function(property)
+		if property == 'DevComputerMovementMode' then
+			ControlModules.Keyboard:RefreshControlStyle()
 		end
+	end)
+	
+	ControlModules.Keyboard.GameSettingsChangedCon = GameSettings.Changed:connect(function(property)
+		if property == 'ComputerMovementMode' then
+			ControlModules.Keyboard:RefreshControlStyle()
+		end
+	end)
+end
+function ControlModules.Keyboard:DisconnectEvents()
+	if ControlModules.Keyboard.LocalPlayerChangedCon then
+		ControlModules.Keyboard.LocalPlayerChangedCon:disconnect()
+		ControlModules.Keyboard.LocalPlayerChangedCon = nil
+	end
+	if ControlModules.Keyboard.GameSettingsChangedCon then
+		ControlModules.Keyboard.GameSettingsChangedCon:disconnect()
+		ControlModules.Keyboard.GameSettingsChangedCon = nil
 	end
 end
 function ControlModules.Keyboard:Disable()
+	ControlModules.Keyboard:DisconnectEvents()
 	local newModuleToDisable = getKeyboardModule()
 	if newModuleToDisable then
 		newModuleToDisable:Disable()


### PR DESCRIPTION
This is a fix for the following bug:
When changing the ComputerMovementMode or DevComputerMovementMode the Keyboard ControlModule does not update. Currently this bug is only observed when switching to/from the Scriptable DevComputerMovementMode. This has the effect of allowing the player to walk around while DevComputerMovementMode is Scriptable, or not allowing the player to walk around when it is anything else. This does not happen with the Touch ControlModule because it listens for changes to (Dev)ComputerMovementMode.

This fix mirrors over the event listening and module refreshing code from the Touch ControlModule to the Keyboard ControlModule in order to remain consistent between the two.
This issue was originally pointed out on the devforum [here](http://devforum.roblox.com/t/changing-devcomputermovementmode-or-devtouchmovementmode-sometimes-doesnt-activate-instantly/26844).


This also fixes an unrelated duplicate check for the same condition inside Keyboard:Enable.