### PR TITLE
Start-time and performance optimizations

### DIFF
--- a/CoreScriptsRoot/CoreScripts/ContextActionTouch.lua
+++ b/CoreScriptsRoot/CoreScripts/ContextActionTouch.lua
@@ -6,6 +6,7 @@
 -- Variables
 local contextActionService = game:GetService("ContextActionService")
 local userInputService = game:GetService("UserInputService")
+local playersService = game:GetService("Players")
 local isTouchDevice = userInputService.TouchEnabled
 local functionTable = {}
 local buttonVector = {}
@@ -32,9 +33,11 @@ local maxButtons = #buttonPositionTable
 game:GetService("ContentProvider"):Preload(ContextDownImage)
 game:GetService("ContentProvider"):Preload(ContextUpImage)
 
-repeat wait() until game:GetService("Players").LocalPlayer
-
-local localPlayer = game:GetService("Players").LocalPlayer
+local localPlayer = playersService.LocalPlayer
+while not localPlayer do
+	playersService.ChildAdded:wait()
+	localPlayer = playersService.LocalPlayer
+end
 
 function createContextActionGui()
 	if not buttonScreenGui and isTouchDevice then

--- a/CoreScriptsRoot/CoreScripts/Topbar.lua
+++ b/CoreScriptsRoot/CoreScripts/Topbar.lua
@@ -70,7 +70,7 @@ local settingsActive = false
 local GameSettings = UserSettings().GameSettings
 local Player = PlayersService.LocalPlayer
 while Player == nil do
-	wait()
+	PlayersService.ChildAdded:wait()
 	Player = PlayersService.LocalPlayer
 end
 

--- a/CoreScriptsRoot/CoreScripts/Topbar.lua
+++ b/CoreScriptsRoot/CoreScripts/Topbar.lua
@@ -69,7 +69,7 @@ local settingsActive = false
 
 local GameSettings = UserSettings().GameSettings
 local Player = PlayersService.LocalPlayer
-while Player == nil do
+while not Player do
 	PlayersService.ChildAdded:wait()
 	Player = PlayersService.LocalPlayer
 end

--- a/CoreScriptsRoot/Modules/Settings/Pages/Players.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/Players.lua
@@ -22,8 +22,11 @@ local frameSelectedTransparency = .65
 
 ------------ Variables -------------------
 local PageInstance = nil
-repeat wait() until PlayersService.LocalPlayer
 local localPlayer = PlayersService.LocalPlayer
+while not localPlayer do
+	PlayersService.ChildAdded:wait()
+	localPlayer = PlayersService.LocalPlayer
+end
 
 ----------- CLASS DECLARATION --------------
 local function Initialize()


### PR DESCRIPTION
ROBLOX's core-scripts were doing a few things in every ROBLOX game (including Studio), that made performance less than optimal.

- Yielding on startup at least one frame (means UI didn't initialize for a whole extra 1/30 seconds)
- Resuming every frame while a LocalPlayer didn't exist

This second point means that ScriptContext was running overhead during studio sessions in resuming scripts that don't need to be resumed. 

Note ChildAdded is being used to wait here, and the parameter not called, due to race conditions and the fact PlayerAdded does not fire on the client. 

There are several more optimizations needed to fix flickering on the TopBar during teleports, and that can optimize performance more, but this is a good initial step to fix some low-hanging fruit. 