### PR TITLE
CLI-10496 Chat menu is getting reset to a default (open) state after teleport

### DIFF
--- a/CoreScriptsRoot/CoreScripts/Topbar.lua
+++ b/CoreScriptsRoot/CoreScripts/Topbar.lua
@@ -46,6 +46,9 @@ local vr3dGuis = (vr3dGuisSuccess and vr3dGuisFlagValue == true)
 local getNewNotificationPathSuccess, newNotificationPathValue = pcall(function() return settings():GetFFlag("UseNewNotificationPathLua") end)
 local newNotificationPath = getNewNotificationPathSuccess and newNotificationPathValue
 
+local newChatVisiblePropSuccess, newChatVisiblePropValue =  pcall(function() return settings():GetFFlag("ChatVisiblePropertyEnabled") end)
+local newChatVisibleProp = (newChatVisiblePropSuccess and newChatVisiblePropValue)
+
 --[[ END OF FFLAG VALUES ]]
 
 
@@ -1158,6 +1161,9 @@ local function CreateChatIcon()
 	local function onChatStateChanged(visible)
 		if not Util.IsTouchDevice() then
 			updateIcon(visible)
+			if newChatVisibleProp then
+				GameSettings.ChatVisible = visible
+			end
 		end
 	end
 
@@ -1197,10 +1203,16 @@ local function CreateChatIcon()
 	if ChatModule.VisibilityStateChanged then
 		ChatModule.VisibilityStateChanged:connect(onChatStateChanged)
 	end
-	onChatStateChanged(ChatModule:GetVisibility())
 
 	if not (Util.IsTouchDevice() or InputService.VREnabled) then
-		ChatModule:SetVisible(true)
+		-- check to see if the chat was disabled
+		local willEnableChat = true
+		if newChatVisibleProp then
+			willEnableChat = GameSettings.ChatVisible
+		end
+		if willEnableChat then
+			ChatModule:SetVisible(true)
+		end
 	end
 
 	local menuItem = CreateMenuItem(chatIconButton)
@@ -1257,6 +1269,9 @@ local function CreateMobileHideChatIcon()
 
 	local function onChatStateChanged(visible)
 		updateIcon(visible)
+		if newChatVisibleProp then
+			GameSettings.ChatVisible = visible
+		end
 	end
 
 	chatHideIconButton.MouseButton1Click:connect(function()

--- a/CoreScriptsRoot/Modules/Chat.lua
+++ b/CoreScriptsRoot/Modules/Chat.lua
@@ -1911,7 +1911,7 @@ local function CreateChatWindowWidget(settings)
 
 	local function CreateChatWindow()
 		-- This really shouldn't be a button, but it is currently needed for VR.
-		local container = Util.Create (true and 'TextButton' or 'Frame')
+		local container = Util.Create (InputService.VREnabled and 'TextButton' or 'Frame')
 		{
 			Name = 'ChatWindowContainer';
 			Size = UDim2.new(0.3, 0, 0.25, 0);


### PR DESCRIPTION
When the flag in the topbar script is enabled, this should allow the chat to maintain its state over multiple game launches/teleports. I also included a few requested changes to the Chat module.