### PR TITLE
CLIMOB-3088 Mobile Controls break when opening the settings while moving

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DPad.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DPad.rbxmx
@@ -12,6 +12,7 @@
 --]]
 
 local Players = game:GetService('Players')
+local GUIS = game:GetService('GuiService')
 
 local DPad = {}
 
@@ -159,6 +160,12 @@ function DPad:Create(parentFrame)
 	
 	DPadFrame.InputEnded:connect(function(inputObject)
 		if inputObject == TouchObject then
+			OnInputEnded()
+		end
+	end)
+	
+	GUIS.MenuOpened:connect(function()
+		if TouchObject then
 			OnInputEnded()
 		end
 	end)

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DPad.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DPad.rbxmx
@@ -12,7 +12,7 @@
 --]]
 
 local Players = game:GetService('Players')
-local GUIS = game:GetService('GuiService')
+local GuiService = game:GetService('GuiService')
 
 local DPad = {}
 
@@ -164,7 +164,7 @@ function DPad:Create(parentFrame)
 		end
 	end)
 	
-	GUIS.MenuOpened:connect(function()
+	GuiService.MenuOpened:connect(function()
 		if TouchObject then
 			OnInputEnded()
 		end

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbpad.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbpad.rbxmx
@@ -13,7 +13,7 @@
 
 local Players = game:GetService('Players')
 local UserInputService = game:GetService('UserInputService')
-local GUIS = game:GetService('GuiService')
+local GuiService = game:GetService('GuiService')
 
 local Thumbpad = {}
 
@@ -218,7 +218,7 @@ function Thumbpad:Create(parentFrame)
 		end
 	end)
 	
-	GUIS.MenuOpened:connect(function()
+	GuiService.MenuOpened:connect(function()
 		if TouchObject then
 			OnInputEnded()
 		end

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
@@ -13,7 +13,7 @@
 --]]
 local Players = game:GetService('Players')
 local UserInputService = game:GetService('UserInputService')
-local GUIS = game:GetService('GuiService')
+local GuiService = game:GetService('GuiService')
 
 local MasterControl = require(script.Parent)
 
@@ -170,7 +170,7 @@ function Thumbstick:Create(parentFrame)
 		end
 	end)
 	
-	GUIS.MenuOpened:connect(function()
+	GuiService.MenuOpened:connect(function()
 		if MoveTouchObject then
 			OnTouchEnded()
 		end

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
@@ -164,16 +164,8 @@ function Thumbstick:Create(parentFrame)
 		MasterControl:SetIsJumping(false)
 	end
 	
-	local OnTouchEndedCnie = nil
-	OnTouchEndedCnie = UserInputService.InputEnded:connect(function(inputObject, isProcessed)
-		if inputObject.UserInputType == Enum.UserInputType.Touch then
-			print("input touch ended")
-		end
-	end)
 	OnTouchEndedCn = UserInputService.TouchEnded:connect(function(inputObject, isProcessed)
-		print("touch was ended")
 		if inputObject == MoveTouchObject then
-			print("touch was movetouchobj")
 			OnTouchEnded()
 		end
 	end)

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
@@ -12,7 +12,7 @@
 --]]
 
 local Players = game:GetService('Players')
-local GUIS = game:GetService('GuiService')
+local GuiService = game:GetService('GuiService')
 
 local TouchJump = {}
 
@@ -82,7 +82,7 @@ function TouchJump:Create(parentFrame)
 		end
 	end)
 	
-	GUIS.MenuOpened:connect(function()
+	GuiService.MenuOpened:connect(function()
 		if touchObject then
 			OnInputEnded()
 		end


### PR DESCRIPTION
The movement and jump controls for mobile would break whenever the settings menu opened while interacting with mobile controls. This fix goes through all the buttons and adds an event listener that stops movement when the menu opens. 