### PR TITLE
CLIXBOX-788 - Internal Dialog: UI Chat Errors

### DIFF
--- a/CoreScriptsRoot/CoreScripts/MainBotChatScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/MainBotChatScript2.lua
@@ -478,6 +478,8 @@ function doDialog(dialog)
 		return
 	else
 		dialog.InUse = true
+		-- only bind if we actual enter the dialog
+		contextActionService:BindCoreAction("Nothing", function() end, false, Enum.UserInputType.Gamepad1, Enum.UserInputType.Gamepad2, Enum.UserInputType.Gamepad3, Enum.UserInputType.Gamepad4)
 		if filterEnabledFixActive then
 			setDialogInUseEvent:FireServer(dialog, true)
 		end
@@ -543,8 +545,6 @@ function startDialog(dialog)
 				gui.Enabled = false
 			end
 		end
-		
-		contextActionService:BindCoreAction("Nothing", function() end, false, Enum.UserInputType.Gamepad1, Enum.UserInputType.Gamepad2, Enum.UserInputType.Gamepad3, Enum.UserInputType.Gamepad4)
 
 		renewKillswitch(dialog)
 


### PR DESCRIPTION
Fixes issue where you could mash X button after leaving the dialog and get stuck. We should only bind the "Nothing" action if we actually enter a dialog. doDialog() has an early exit condition, which would leave the "Nothing" action bound.