### PR TITLE
CLI-10825 Keyboard shortcuts for changing quality (F10 and Shift+F10)…

### DIFF
--- a/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
@@ -144,8 +144,8 @@ local function Initialize()
 		end
 
 		game.GraphicsQualityChangeRequest:connect(function(isIncrease)
-			if settings().Rendering.QualityLevel == Enum.QualityLevel.Automatic then return end
-			--
+			--  was using settings().Rendering.Quality level, which was wrongly saying it was automatic.
+			if GameSettings.SavedQualityLevel == Enum.SavedQualitySetting.Automatic then return end
 			local currentGraphicsSliderValue = this.GraphicsQualitySlider:GetValue()
 			if isIncrease then
 				currentGraphicsSliderValue = currentGraphicsSliderValue + 1


### PR DESCRIPTION
… are not working when game menu is open

This was using what seems to be a broken property in settings().Rendering to check the quality level. I changed it to using what the rest of the code uses for checking the quality level, and that seems to have solved the issue.