### PR TITLE
CLIXBOX-671 - Playerlist must always be accessible from Radial Menu

### DIFF
--- a/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
+++ b/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
@@ -28,20 +28,6 @@ local isTenFootInterface = tenFootInterface:IsEnabled()
 local radialButtons = {}
 local lastInputChangedCon = nil
 
-local function getButtonForCoreGuiType(coreGuiType)
-	if coreGuiType == Enum.CoreGuiType.All then
-		return radialButtons
-	else
-		for button, table in pairs(radialButtons) do
-			if table["CoreGuiType"] == coreGuiType then
-				return button
-			end
-		end
-	end
-
-	return nil
-end
-
 local function getImagesForSlot(slot)
 	if slot == 1 then		return "rbxasset://textures/ui/Settings/Radial/Top.png", "rbxasset://textures/ui/Settings/Radial/TopSelected.png",
 									"rbxasset://textures/ui/Settings/Radial/Menu.png",
@@ -643,30 +629,27 @@ local function setupGamepadControls()
 		end)
 	end
 
-	local function setRadialButtonEnabled(coreGuiType, enabled)
-		local returnValue = getButtonForCoreGuiType(coreGuiType)
-		if not returnValue then return end
-
-		local buttonsToDisable = {}
-		if type(returnValue) == "table" then
-			for button, buttonTable in pairs(returnValue) do
-				if buttonTable["CoreGuiType"] then
-					if isTenFootInterface and buttonTable["CoreGuiType"] == Enum.CoreGuiType.Chat then
-					else
-						buttonsToDisable[#buttonsToDisable + 1] = button
-					end
-				end
-			end
-		else
-			if isTenFootInterface and returnValue.Name == "Chat" then
-			else
-				buttonsToDisable[1] = returnValue
+	-- some buttons always show/hide depending on platform
+	local function canChangeButtonVisibleState(buttonType)
+		if isTenFootInterface then
+			if buttonType == Enum.CoreGuiType.Chat or buttonType == Enum.CoreGuiType.PlayerList then
+				return false
 			end
 		end
 
-		for i = 1, #buttonsToDisable do
-			local button = buttonsToDisable[i]
-			setButtonEnabled(button, enabled)
+		return true
+	end
+
+	local function setRadialButtonEnabled(coreGuiType, enabled)
+		for button, buttonTable in pairs(radialButtons) do
+			local buttonType = buttonTable["CoreGuiType"]
+			if buttonType then
+				if coreGuiType == buttonType or coreGuiType == Enum.CoreGuiType.All then
+					if canChangeButtonVisibleState(buttonType) then
+						setButtonEnabled(button, enabled)
+					end
+				end
+			end
 		end
 	end
 	

--- a/CoreScriptsRoot/Modules/PlayerlistModule.lua
+++ b/CoreScriptsRoot/Modules/PlayerlistModule.lua
@@ -1715,6 +1715,12 @@ end
 -- NOTE: Core script only
 local function onCoreGuiChanged(coreGuiType, enabled)
 	if coreGuiType == Enum.CoreGuiType.All or coreGuiType == Enum.CoreGuiType.PlayerList then
+		-- on console we can always toggle on/off, ignore change
+		if isTenFootInterface then
+			playerlistCoreGuiEnabled = true
+			return
+		end
+
 		playerlistCoreGuiEnabled = enabled and topbarEnabled
 
 		-- not visible on small screen devices


### PR DESCRIPTION
You can now open a players Xbox gamer card from the playerlist, so playerlist needs to always be enabled on Xbox. This is to allow players to block/mute other users from in-game.