### PR TITLE
Fix ZIndex issue with gamepad menu

### DIFF
--- a/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
+++ b/CoreScriptsRoot/CoreScripts/GamepadMenu.lua
@@ -179,7 +179,7 @@ local function createRadialButton(name, text, slot, disabled, coreGuiType, activ
 		TextColor3 = Color3.new(1,1,1),
 		Name = "RadialLabel",
 		Visible = false,
-		ZIndex = 2,
+		ZIndex = 3,
 		Parent = radialButton
 	};
 	if not smallScreen then


### PR DESCRIPTION
The gui render order fix caused a regression with the gamepad menu. This fixes that by updated the ZIndex of the text label to render over the button.