### PR TITLE
Recenter is more usable and can be canceled via the following actions:

### DIFF
--- a/CoreScriptsRoot/Modules/VR/Recenter.lua
+++ b/CoreScriptsRoot/Modules/VR/Recenter.lua
@@ -6,7 +6,7 @@ local Panel3D = require(RobloxGui.Modules.VR.Panel3D)
 local VRHub = require(RobloxGui.Modules.VR.VRHub)
 local Util = require(RobloxGui.Modules.Settings.Utility)
 
-local cancelShortcutName = game:GetService("HttpService"):GenerateGUID()
+local cancelShortcutName = "CancelRecenterShortcut"
 
 local RecenterModule = {}
 RecenterModule.ModuleName = "Recenter"


### PR DESCRIPTION
 - Opening another module (settings, chat, notifications, etc)
 - Pressing the B button
 - Pressing the ESC button (will open settings)
 - Activating the recenter button again