### PR TITLE
Add Http module in common directory

### DIFF
--- a/CoreScriptsRoot/Modules/Common/Http.lua
+++ b/CoreScriptsRoot/Modules/Common/Http.lua
@@ -1,0 +1,117 @@
+--[[
+                // Http.lua
+
+                // API for making http calls into roblox endpoints
+]]
+local HttpService = game:GetService('HttpService')
+local HttpRbxApiService = game:GetService('HttpRbxApiService')
+
+local Http = {} -- module return table
+
+local BaseUrl = game:GetService('ContentProvider').BaseUrl:lower()
+BaseUrl = string.gsub(BaseUrl, "/m.", "/www.")
+BaseUrl = string.gsub(BaseUrl, "http://", "https://")
+
+local AssetGameBaseUrl = string.gsub(BaseUrl, "https://www.", "https://assetgame.")
+
+
+function Http.GetBaseUrl()
+    return BaseUrl
+end
+function Http.GetAssetGameBaseUrl()
+    return AssetGameBaseUrl
+end
+
+function Http.DecodeJSON(json)
+    local success, result = pcall(function()
+        return HttpService:JSONDecode(json)
+    end)
+    if not success then
+        print("Http.DecodeJSON() failed because", result, "for input:", json)
+        return
+    end
+
+    return result
+end
+
+function Http.EncodeJSON(jsonTable)
+    local success, result = pcall(function()
+        return HttpService:JSONEncode(jsonTable)
+    end)
+    if not success then
+        print("Http.EncodeJSON() failed because", result)
+        return
+    end
+
+    return result
+end
+
+function Http.RbxGetAsync(path, returnRaw)
+    local success, result = pcall(function()
+        return game:HttpGetAsync(path)
+    end)
+    if not success then
+        print("Http.RbxGetAsync() failed because", result, "for path:", path)
+        return
+    end
+
+    if returnRaw then
+        return result
+    end
+    
+    return Http.DecodeJSON(result)
+end
+
+function Http.RbxPostAsync(path, returnRaw)
+    local success, result = pcall(function()
+        return game:HttpPostAsync(path, '')
+    end)
+    if not success then
+        print("Http.RbxPostAsync() failed because", result, "for path:", path)
+        return
+    end
+
+    if returnRaw then
+        return result
+    end
+
+    return Http.DecodeJSON(result)
+end
+
+function Http.RbxApiGetAsync(path, throttlePriority, returnRaw)
+    -- throttlePriority: defaults to Enum.ThrottlingPriority.Default through reflection
+    local success, result = pcall(function()
+        return HttpRbxApiService:GetAsync(path, true, throttlePriority)
+    end)
+    if not success then
+        print("Http.RbxApiGetAsync() failed because", result, "for path:", path)
+        return
+    end
+
+    if returnRaw then
+        return result
+    end
+
+    return Http.DecodeJSON(result)
+end
+
+function Http.RbxApiPostAsync(path, params, throttlePriority, contentType, returnRaw)
+    -- throttlePriority: defaults to Enum.ThrottlingPriority.Default through reflection
+    -- contentType: defaults to Enum.HttpContentType.ApplicationJson through reflection
+    local success, result = pcall(function()
+        return HttpRbxApiService:PostAsync(path, params, true, throttlePriority, contentType)
+    end)
+
+    if not success then
+        print("Http.RbxApiPostAsync() failed because", result, "for path:", path)
+        return
+    end
+
+    if returnRaw then
+        return result
+    end
+
+    return Http.DecodeJSON(result)
+end
+
+return Http


### PR DESCRIPTION
Adding new Http module to reduce the amount of code needed when making Roblox endpoint calls in CoreScripts. The module wraps all http API calls in pcalls, which is where most of the code redundancy comes from. Each call will decode the json into a lua table, and I have added an optional returnRaw parameter if you need the raw json.

This has been updated and added to the new Common directory. This will not conflict with the Xbox app http module (we may want to reorganize that project to reduce future conflicts). Module has been added to Common as it has use on both the server and the client.

After this is approved, we can start migrating existing calls to use this module.