### PR TITLE
CLIMOB-3351 Mobile touch control thumbstick initial touch not centered

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
@@ -141,7 +141,6 @@ function Thumbstick:Create(parentFrame)
 		centerPosition = Vector2.new(ThumbstickFrame.AbsolutePosition.x + ThumbstickFrame.AbsoluteSize.x/2,
 			ThumbstickFrame.AbsolutePosition.y + ThumbstickFrame.AbsoluteSize.y/2)
 		local direction = Vector2.new(inputObject.Position.x - centerPosition.x, inputObject.Position.y - centerPosition.y)
-		moveStick(inputObject.Position)
 	end)
 	
 	OnTouchMovedCn = UserInputService.TouchMoved:connect(function(inputObject, isProcessed)


### PR DESCRIPTION
Calling moveStick() in InputBegan was unnecessary because if the frame is centering itself where you clicked down, it should still be at the center (where it is by default). In addition, this was causing the button not to be centered until moved.