### PR TITLE
Fix zIndex issue on mobile help menu.

### DIFF
--- a/CoreScriptsRoot/Modules/Settings/Pages/Help.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/Help.lua
@@ -292,7 +292,7 @@ local function Initialize()
 				FontSize = Enum.FontSize.Size14,
 				TextColor3 = Color3.new(1,1,1),
 				Name = text .. "Label",
-				ZIndex = 2,
+				ZIndex = 3,
 				Parent = parent
 			};
 			if not smallScreen then


### PR DESCRIPTION
z ordering recently changed so that text at same index as other children
no longer renders on top of other children.