### PR TITLE
CLI-13102 Gamepad Button Selection activates when opening Backpack without gamepad connected

### DIFF
--- a/CoreScriptsRoot/Modules/BackpackScript.lua
+++ b/CoreScriptsRoot/Modules/BackpackScript.lua
@@ -1049,7 +1049,6 @@ local function getInputDirection(inputObject)
 end
 
 local selectToolExperiment = function(actionName, inputState, inputObject)
-
 	local inputDirection = getInputDirection(inputObject)
 
 	if inputDirection == Vector2.new(0,0) then
@@ -1675,8 +1674,9 @@ do -- Make the Inventory expand/collapse arrow (unless TopBar)
 					resizeGamepadHintsFrame()
 					gamepadHintsFrame.Visible = not UserInputService.VREnabled
 				end
+				enableGamepadInventoryControl()
 			end
-			enableGamepadInventoryControl()
+			
 		else
 			if GamepadEnabled then
 				gamepadHintsFrame.Visible = false


### PR DESCRIPTION
Was calling this from outside the scope that checked if gamepad controls
were enabled, thus enabling the selection UI for all platforms.