### PR TITLE
CLI-13103 Opening the Escape menu doesn't stop the camera from panning

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
@@ -9,6 +9,7 @@
 local PlayersService = game:GetService('Players')
 local UserInputService = game:GetService('UserInputService')
 local StarterGui = game:GetService('StarterGui')
+local GuiService = game:GetService('GuiService')
 
 local HasVRAPI = false
 pcall(function() HasVRAPI = UserInputService.GetUserCFrame ~= nil end)
@@ -869,7 +870,7 @@ local function CreateCamera()
 		return Vector2.new(0,0)
 	end
 
-	local InputBeganConn, InputChangedConn, InputEndedConn, ShiftLockToggleConn, GamepadConnectedConn, GamepadDisconnectedConn = nil, nil, nil, nil, nil, nil
+	local InputBeganConn, InputChangedConn, InputEndedConn, MenuOpenedConn, ShiftLockToggleConn, GamepadConnectedConn, GamepadDisconnectedConn = nil, nil, nil, nil, nil, nil, nil
 
 	function this:DisconnectInputEvents()
 		if InputBeganConn then
@@ -883,6 +884,10 @@ local function CreateCamera()
 		if InputEndedConn then
 			InputEndedConn:disconnect()
 			InputEndedConn = nil
+		end
+		if MenuOpenedConn then
+			MenuOpenedConn:disconnect()
+			MenuOpenedConn = nil
 		end
 		if ShiftLockToggleConn then
 			ShiftLockToggleConn:disconnect()
@@ -972,6 +977,28 @@ local function CreateCamera()
 			-- Keyboard
 			if input.UserInputType == Enum.UserInputType.Keyboard then
 				OnKeyUp(input, processed)
+			end
+		end)
+		
+		MenuOpenedConn = GuiService.MenuOpened:connect(function()
+			isRightMouseDown = false
+			isMiddleMouseDown = false
+			OnMousePanButtonReleased() -- this function doesn't seem to actually need parameters
+			
+			if UserInputService.TouchEnabled then
+				--[[menu opening was causing serious touch issues
+				this should disable all active touch events if 
+				they're active when menu opens.]]
+				for inputObject, value in pairs(fingerTouches) do
+					fingerTouches[inputObject] = nil
+				end
+				panBeginLook = nil
+				startPos = nil
+				lastPos = nil
+				this.UserPanningTheCamera = false	
+				StartingDiff = nil
+				pinchBeginZoom = nil
+				NumUnsunkTouches = 0
 			end
 		end)
 

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
@@ -1,3 +1,11 @@
+<roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
+	<External>null</External>
+	<External>nil</External>
+	<Item class="ModuleScript" referent="RBXA74A5A1BA29543E288C039551D27D876">
+		<Properties>
+			<Content name="LinkedSource"><null></null></Content>
+			<string name="Name">RootCamera</string>
+			<ProtectedString name="Source"><![CDATA[
 
 local PlayersService = game:GetService('Players')
 local UserInputService = game:GetService('UserInputService')
@@ -1167,3 +1175,7 @@ local function CreateCamera()
 end
 
 return CreateCamera
+]]></ProtectedString>
+		</Properties>
+	</Item>
+</roblox>

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
@@ -6,7 +6,6 @@
 			<Content name="LinkedSource"><null></null></Content>
 			<string name="Name">RootCamera</string>
 			<ProtectedString name="Source"><![CDATA[
-
 local PlayersService = game:GetService('Players')
 local UserInputService = game:GetService('UserInputService')
 local StarterGui = game:GetService('StarterGui')

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
@@ -1,11 +1,4 @@
-<roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
-	<External>null</External>
-	<External>nil</External>
-	<Item class="ModuleScript" referent="RBXA74A5A1BA29543E288C039551D27D876">
-		<Properties>
-			<Content name="LinkedSource"><null></null></Content>
-			<string name="Name">RootCamera</string>
-			<ProtectedString name="Source"><![CDATA[
+
 local PlayersService = game:GetService('Players')
 local UserInputService = game:GetService('UserInputService')
 local StarterGui = game:GetService('StarterGui')
@@ -940,6 +933,28 @@ local function CreateCamera()
 			UserInputService.MouseBehavior = Enum.MouseBehavior.Default
 		end
 	end
+	
+	function this:ResetInputStates()
+		isRightMouseDown = false
+		isMiddleMouseDown = false
+		OnMousePanButtonReleased() -- this function doesn't seem to actually need parameters
+		
+		if UserInputService.TouchEnabled then
+			--[[menu opening was causing serious touch issues
+			this should disable all active touch events if 
+			they're active when menu opens.]]
+			for inputObject, value in pairs(fingerTouches) do
+				fingerTouches[inputObject] = nil
+			end
+			panBeginLook = nil
+			startPos = nil
+			lastPos = nil
+			this.UserPanningTheCamera = false	
+			StartingDiff = nil
+			pinchBeginZoom = nil
+			NumUnsunkTouches = 0
+		end
+	end
 
 	function this:ConnectInputEvents()
 		InputBeganConn = UserInputService.InputBegan:connect(function(input, processed)
@@ -981,25 +996,7 @@ local function CreateCamera()
 		end)
 		
 		MenuOpenedConn = GuiService.MenuOpened:connect(function()
-			isRightMouseDown = false
-			isMiddleMouseDown = false
-			OnMousePanButtonReleased() -- this function doesn't seem to actually need parameters
-			
-			if UserInputService.TouchEnabled then
-				--[[menu opening was causing serious touch issues
-				this should disable all active touch events if 
-				they're active when menu opens.]]
-				for inputObject, value in pairs(fingerTouches) do
-					fingerTouches[inputObject] = nil
-				end
-				panBeginLook = nil
-				startPos = nil
-				lastPos = nil
-				this.UserPanningTheCamera = false	
-				StartingDiff = nil
-				pinchBeginZoom = nil
-				NumUnsunkTouches = 0
-			end
+			this:ResetInputStates()
 		end)
 
 		workspaceChangedConn = workspace.Changed:connect(function(prop)
@@ -1170,7 +1167,3 @@ local function CreateCamera()
 end
 
 return CreateCamera
-]]></ProtectedString>
-		</Properties>
-	</Item>
-</roblox>


### PR DESCRIPTION
When the menu opens, the camera should stop panning, and on mobile, touch events will be ended, fixing an issue that caused panning to break.