### PR TITLE
SetCore and GetCore DeveloperConsoleVisible.

### DIFF
--- a/CoreScriptsRoot/Modules/DeveloperConsoleModule.lua
+++ b/CoreScriptsRoot/Modules/DeveloperConsoleModule.lua
@@ -3054,8 +3054,7 @@ StarterGui:RegisterGetCore("DeveloperConsoleVisible", function()
 end)
 StarterGui:RegisterSetCore("DeveloperConsoleVisible", function(visible)
 	if (type(visible) ~= "boolean") then
-		warn("DeveloperConsoleVisible must be given a boolean value.")
-		return
+		error("DeveloperConsoleVisible must be given a boolean value.")
 	end
 
 	if (not myDeveloperConsole) then

--- a/CoreScriptsRoot/Modules/DeveloperConsoleModule.lua
+++ b/CoreScriptsRoot/Modules/DeveloperConsoleModule.lua
@@ -2990,15 +2990,24 @@ local function onDevConsoleVisibilityChanged(isVisible)
 	end
 end
 
+local getDeveloperConsoleIsCreating = false
 local function getDeveloperConsole()
-	if not myDeveloperConsole then
-		local permissions = DeveloperConsole.GetPermissions()
-		local messagesAndStats = DeveloperConsole.GetMessagesAndStats(permissions)
+	if (not myDeveloperConsole) then
+		if (not getDeveloperConsoleIsCreating) then
+			getDeveloperConsoleIsCreating = true
 
-		myDeveloperConsole = DeveloperConsole.new(RobloxGui, permissions, messagesAndStats)
+			local permissions = DeveloperConsole.GetPermissions()
+			local messagesAndStats = DeveloperConsole.GetMessagesAndStats(permissions)
 
-		if isTenFootInterface then
-			myDeveloperConsole.VisibleChanged:connect(onDevConsoleVisibilityChanged)
+			myDeveloperConsole = DeveloperConsole.new(RobloxGui, permissions, messagesAndStats)
+
+			if isTenFootInterface then
+				myDeveloperConsole.VisibleChanged:connect(onDevConsoleVisibilityChanged)
+			end
+
+			getDeveloperConsoleIsCreating = false
+		else
+			while (getDeveloperConsoleIsCreating) do wait() end
 		end
 	end
 

--- a/CoreScriptsRoot/Modules/DeveloperConsoleModule.lua
+++ b/CoreScriptsRoot/Modules/DeveloperConsoleModule.lua
@@ -3015,4 +3015,46 @@ function DevConsoleModuleTable:SetVisibility(value)
 	devConsole:SetVisible(value)
 end
 
+
+local creatingLock = false
+local creatingVisibleValueToSet = false
+
+local function SetCoreConsoleCreation()
+	if (creatingLock) then return end
+	creatingLock = true
+
+	spawn(function()
+		--// Keep GetVisibility call before SetVisibility because the first call will yield for some time and 
+		--// there is the possibility that during the yield time the value of 'creatingVisibleValueToSet' may
+		--// change.
+		DevConsoleModuleTable:GetVisibility()
+		DevConsoleModuleTable:SetVisibility(creatingVisibleValueToSet)
+
+		creatingLock = false
+	end)
+end
+
+local StarterGui = game:GetService("StarterGui")
+StarterGui:RegisterGetCore("DeveloperConsoleVisible", function()
+	if (not myDeveloperConsole) then
+		SetCoreConsoleCreation()
+		return creatingVisibleValueToSet;
+	else
+		return DevConsoleModuleTable:GetVisibility()
+	end
+end)
+StarterGui:RegisterSetCore("DeveloperConsoleVisible", function(visible)
+	if (type(visible) ~= "boolean") then
+		warn("DeveloperConsoleVisible must be given a boolean value.")
+		return
+	end
+
+	if (not myDeveloperConsole) then
+		creatingVisibleValueToSet = visible
+		SetCoreConsoleCreation()
+	else
+		DevConsoleModuleTable:SetVisibility(visible)
+	end
+end)
+
 return DevConsoleModuleTable


### PR DESCRIPTION
Allows developers to get and set the visibility state of the developer console from Lua.