### PR TITLE
Moving debounce to a lower level

### DIFF
--- a/CoreScriptsRoot/Modules/DeveloperConsoleModule.lua
+++ b/CoreScriptsRoot/Modules/DeveloperConsoleModule.lua
@@ -2719,12 +2719,16 @@ end
 -- Permissions --
 -----------------
 do
-	local permissions;
+	local permissionsLoading, permissions = false;
 	function DeveloperConsole.GetPermissions()
+		while permissionsLoading do wait() end
+		
 		if permissions then
 			return permissions
 		end
+		
 		permissions = {}
+		permissionsLoading = true
 		
 		pcall(function()
 			permissions.CreatorFlagValue = settings():GetFFlag("UseCanManageApiToDetermineConsoleAccess")
@@ -2771,8 +2775,9 @@ do
 		permissions.MayViewServerScripts = permissions.IsCreator
 		permissions.MayViewServerJobs = permissions.IsCreator
 		
-		return permissions
+		permissionsLoading = false
 		
+		return permissions
 	end
 end
 
@@ -2990,24 +2995,15 @@ local function onDevConsoleVisibilityChanged(isVisible)
 	end
 end
 
-local getDeveloperConsoleIsCreating = false
 local function getDeveloperConsole()
 	if (not myDeveloperConsole) then
-		if (not getDeveloperConsoleIsCreating) then
-			getDeveloperConsoleIsCreating = true
+		local permissions = DeveloperConsole.GetPermissions()
+		local messagesAndStats = DeveloperConsole.GetMessagesAndStats(permissions)
 
-			local permissions = DeveloperConsole.GetPermissions()
-			local messagesAndStats = DeveloperConsole.GetMessagesAndStats(permissions)
+		myDeveloperConsole = DeveloperConsole.new(RobloxGui, permissions, messagesAndStats)
 
-			myDeveloperConsole = DeveloperConsole.new(RobloxGui, permissions, messagesAndStats)
-
-			if isTenFootInterface then
-				myDeveloperConsole.VisibleChanged:connect(onDevConsoleVisibilityChanged)
-			end
-
-			getDeveloperConsoleIsCreating = false
-		else
-			while (getDeveloperConsoleIsCreating) do wait() end
+		if isTenFootInterface then
+			myDeveloperConsole.VisibleChanged:connect(onDevConsoleVisibilityChanged)
 		end
 	end
 

--- a/CoreScriptsRoot/Modules/DeveloperConsoleModule.lua
+++ b/CoreScriptsRoot/Modules/DeveloperConsoleModule.lua
@@ -2995,15 +2995,24 @@ local function onDevConsoleVisibilityChanged(isVisible)
 	end
 end
 
+local getDeveloperConsoleIsCreating = false
 local function getDeveloperConsole()
 	if (not myDeveloperConsole) then
-		local permissions = DeveloperConsole.GetPermissions()
-		local messagesAndStats = DeveloperConsole.GetMessagesAndStats(permissions)
+		if (not getDeveloperConsoleIsCreating) then
+			getDeveloperConsoleIsCreating = true
 
-		myDeveloperConsole = DeveloperConsole.new(RobloxGui, permissions, messagesAndStats)
+			local permissions = DeveloperConsole.GetPermissions()
+			local messagesAndStats = DeveloperConsole.GetMessagesAndStats(permissions)
 
-		if isTenFootInterface then
-			myDeveloperConsole.VisibleChanged:connect(onDevConsoleVisibilityChanged)
+			myDeveloperConsole = DeveloperConsole.new(RobloxGui, permissions, messagesAndStats)
+
+			if isTenFootInterface then
+				myDeveloperConsole.VisibleChanged:connect(onDevConsoleVisibilityChanged)
+			end
+
+			getDeveloperConsoleIsCreating = false
+		else
+			while (getDeveloperConsoleIsCreating) do wait() end
 		end
 	end
 


### PR DESCRIPTION
Moving the debounce from *getDeveloperConsole()* to *DeveloperConsole.GetPermissions()*
(Fixing GetPermissions() also fixes getDeveloperConsole() as the first one was the actual culprit)

After reviewing some stuff, it seems that fixing the culprit (GetPermissions() yielding) seems better.
Having GetPermissions() be a true singleton, instead of singleton-after-it-loaded also fixes getDeveloperConsole().

*(I should've done this in my pull request yesterday, but oh well)*