### PR TITLE
CLISTUDIO-9580: SpawnLocation doesn't orient correctly in first person

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
@@ -1115,7 +1115,7 @@ local function CreateCamera()
 		end)
 
 		local function OnCharacterAdded(newCharacter)
-			this:ZoomCamera(12.5)
+			
 			local humanoid = findPlayerHumanoid(player)
 			local start = tick()
 			while tick() - start < 0.3 and (humanoid == nil or humanoid.Torso == nil) do
@@ -1139,8 +1139,10 @@ local function CreateCamera()
 					this.LastCameraTransform = nil
 				end
 			end
-			wait()
+			
 			setLookBehindCharacter()
+			wait()
+			this:ZoomCamera(12.5)
 		end
 
 		player.CharacterAdded:connect(function(character)


### PR DESCRIPTION
Setting CameraMode to LockFirstPerson will cause the ZoomCamera call to
zoom to 0. This causes the character to move to face camera. We want to
orient the camera before we zoom
