### PR TITLE
CLI-3017 Mobile Jump Button Should Disappear If Jumping Disabled

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl.rbxmx
@@ -35,8 +35,9 @@ local isSeated = false
 local myVehicleSeat = nil
 local moveValue = Vector3.new(0,0,0)
 
+
 --[[ Local Functions ]]--
-local function getHumanoid()
+function MasterControl:GetHumanoid()
 	local character = LocalPlayer and LocalPlayer.Character
 	if character then
 		if CachedHumanoid and CachedHumanoid.Parent == character then
@@ -58,7 +59,7 @@ function MasterControl:Init()
 	
 	local renderStepFunc = function()
 		if LocalPlayer and LocalPlayer.Character then
-			local humanoid = getHumanoid()
+			local humanoid = self:GetHumanoid()
 			if not humanoid then return end
 			
 			if humanoid and not humanoid.PlatformStand and isJumping then
@@ -74,6 +75,8 @@ function MasterControl:Init()
 			end
 			
 			moveFunc(LocalPlayer, adjustedMoveValue, true)	
+			
+			
 		end
 	end
 	
@@ -111,7 +114,7 @@ function MasterControl:SetIsJumping(jumping)
 end
 
 function MasterControl:DoJump()
-	local humanoid = getHumanoid()
+	local humanoid = self:GetHumanoid()
 	if humanoid then
 		humanoid.Jump = true
 	end

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
@@ -35,7 +35,9 @@ local TOUCH_CONTROL_SHEET = "rbxasset://textures/ui/TouchControlsSheet.png"
 
 --[[ Public API ]]--
 function TouchJump:Enable()
-	JumpButton.Visible = true
+	if humanoid.JumpPower > 0 and not JumpButton.Visible then
+		JumpButton.Visible = true
+	end
 end
 
 function TouchJump:Disable()
@@ -99,6 +101,7 @@ function TouchJump:Create(parentFrame)
 	end)
 	
 	if humanoid then
+		
 		humanoid.Changed:connect(function(prop)
 			if prop == "JumpPower" then
 				if humanoid.JumpPower < 1 and JumpButton.Visible then

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
@@ -26,6 +26,7 @@ while not Players.LocalPlayer do
 	wait()
 end
 local LocalPlayer = Players.LocalPlayer
+local humanoid = MasterControl:GetHumanoid()
 local JumpButton = nil
 local OnInputEnded = nil		-- defined in Create()
 
@@ -97,6 +98,17 @@ function TouchJump:Create(parentFrame)
 		end
 	end)
 	
+	if humanoid then
+		humanoid.Changed:connect(function(prop)
+			if prop == "JumpPower" then
+				if humanoid.JumpPower < 1 and JumpButton.Visible then
+					TouchJump:Disable()
+				elseif humanoid.JumpPower > 0 and not JumpButton.Visible then
+					TouchJump:Enable()
+				end
+			end
+		end)
+	end
 	JumpButton.Parent = parentFrame
 end
 

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
@@ -26,23 +26,53 @@ while not Players.LocalPlayer do
 	wait()
 end
 local LocalPlayer = Players.LocalPlayer
-local humanoid = MasterControl:GetHumanoid()
+local Humanoid = MasterControl:GetHumanoid()
 local JumpButton = nil
 local OnInputEnded = nil		-- defined in Create()
+local HumChangeConnection = nil
+local ExternallyEnabled = false --[[I don't think there's anything that disables jump from outside this script, but in case that ever happens, 
+							we don't want to re-enable it when jump power is changed]]
 
 --[[ Constants ]]--
 local TOUCH_CONTROL_SHEET = "rbxasset://textures/ui/TouchControlsSheet.png"
 
---[[ Public API ]]--
-function TouchJump:Enable()
-	if humanoid.JumpPower > 0 and not JumpButton.Visible then
-		JumpButton.Visible = true
+--[[ Private Functions ]]--
+local function humanoidChanged(prop)
+	if prop == "JumpPower" then
+		if Humanoid.JumpPower == 0 then
+			TouchJump:Disable()
+		elseif Humanoid.JumpPower > 0 then
+			TouchJump:Enable()
+		end
+	elseif prop == "Parent" then
+		if not Humanoid.Parent then
+			HumChangeConnection:disconnect()
+		end
 	end
 end
 
-function TouchJump:Disable()
+local function disableButton()
 	JumpButton.Visible = false
 	OnInputEnded()
+end
+
+local function enableButton()
+	if Humanoid and ExternallyEnabled then
+		if Humanoid.JumpPower > 0 then
+			JumpButton.Visible = true
+		end
+	end
+end
+
+--[[ Public API ]]--
+function TouchJump:Enable()
+	ExternallyEnabled = true
+	enableButton()
+end
+
+function TouchJump:Disable()
+	ExternallyEnabled = false
+	disableButton()
 end
 
 function TouchJump:Create(parentFrame)
@@ -100,20 +130,24 @@ function TouchJump:Create(parentFrame)
 		end
 	end)
 	
-	if humanoid then
-		
-		humanoid.Changed:connect(function(prop)
-			if prop == "JumpPower" then
-				if humanoid.JumpPower < 1 and JumpButton.Visible then
-					TouchJump:Disable()
-				elseif humanoid.JumpPower > 0 and not JumpButton.Visible then
-					TouchJump:Enable()
-				end
-			end
-		end)
+	if Humanoid then
+		HumChangeConnection = Humanoid.Changed:connect(humanoidChanged)
 	end
 	JumpButton.Parent = parentFrame
 end
+
+LocalPlayer.CharacterAdded:connect(function(newCharacter)
+	if HumChangeConnection then
+		HumChangeConnection:disconnect()
+	end
+	-- rebind event to new Humanoid
+	Humanoid = nil
+	repeat
+		Humanoid = MasterControl:GetHumanoid()
+		wait()
+	until Humanoid and Humanoid.Parent == newCharacter
+	HumChangeConnection = Humanoid.Changed:connect(humanoidChanged)
+end)
 
 return TouchJump
 ]]></ProtectedString>


### PR DESCRIPTION
This edit makes it so that the jump button disappears if the character's humanoid's jump power is set to 0. If it goes higher, then the button gets reenabled.