### PR TITLE
CLIXBOX-865 - Avatar icons not showing in playerlist

### DIFF
--- a/CoreScriptsRoot/Modules/PlayerlistModule.lua
+++ b/CoreScriptsRoot/Modules/PlayerlistModule.lua
@@ -215,8 +215,8 @@ local function setAvatarIconAsync(player, iconImage)
 
   local thumbnailLoader = nil
   pcall(function()
-      thumbnailLoader = require(RobloxGui.Modules.ThumbnailLoader)
-    end)
+    thumbnailLoader = require(RobloxGui.Modules.Shell.ThumbnailLoader)
+  end)
 
   local isFinalSuccess = false
   if thumbnailLoader then


### PR DESCRIPTION
This stopped working after we moved the app shell scripts.