### PR TITLE
Add PascalCase aliases to Signal methods

### DIFF
--- a/CoreScriptsRoot/Libraries/RbxUtility.lua
+++ b/CoreScriptsRoot/Libraries/RbxUtility.lua
@@ -794,6 +794,7 @@ function t.CreateSignal()
 			cn:disconnect()
 			mAllCns[cn] = nil
 		end
+		pubCn.Disconnect = pubCn.disconnect
 		return pubCn
 	end
 	function this:disconnect()
@@ -811,6 +812,12 @@ function t.CreateSignal()
 		if self ~= this then error("fire must be called with `:`, not `.`", 2) end
 		mBindableEvent:Fire(...)
 	end
+
+	--aliases
+	this.Connect = this.connect
+	this.Disconnect = this.disconnect
+	this.Wait = this.wait
+	this.Fire = this.fire
 
 	return this
 end


### PR DESCRIPTION
Fix to align Signal method names consistently with recent deprecation of :connect and :disconnect in favor of :Connect and :Disconnect (http://devforum.roblox.com/t/roblox-official-changelog/25964/18)