### PR TITLE
Fix developer console server log showing incorrect timestamp

### DIFF
--- a/CoreScriptsRoot/Modules/DeveloperConsoleModule.lua
+++ b/CoreScriptsRoot/Modules/DeveloperConsoleModule.lua
@@ -2903,10 +2903,10 @@ do
 				
 				local LogService = game:GetService("LogService")
 				
-				LogService.ServerMessageOut:connect(function(text, messageType)
+				LogService.ServerMessageOut:connect(function(text, messageType, timestamp)
 					local message = {
 						Message = text or "[DevConsole Error 3]";
-						Time = ConvertTimeStamp(os_time());
+						Time = ConvertTimeStamp(timestamp);
 						Type = messageType.Value;
 					}
 					if not filterMessageOnAdd(message) then


### PR DESCRIPTION
The timestamp saved on server for earlier messages should be used when
LogService:RequestServerOutput() is called.