### PR TITLE
Kick players when they leave

### DIFF
--- a/CoreScriptsRoot/ServerStarterScript.lua
+++ b/CoreScriptsRoot/ServerStarterScript.lua
@@ -57,6 +57,7 @@ game:GetService("Players").PlayerRemoving:connect(function(player)
 			end
 		end
 	end
+	player:Kick()
 end)
 
 local success, retVal = pcall(function() return game:GetService("Chat"):GetShouldUseLuaChat() end)


### PR DESCRIPTION
Kick a player when their player is removed, to prevent an exploiter from placing themselves into nil to avoid being indexed.