### PR TITLE
Performance stats less printing

### DIFF
--- a/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
@@ -555,16 +555,21 @@ local function CreateSettingsHub()
   end
 
   local function toggleQuickProfilerFromHotkey(actionName, inputState, inputObject) 
+    print("001")
     -- Make sure it's Ctrl-F7.
     -- NOTE: This will only work if FFlagDontSwallowInputForStudioShortcuts is True.
     -- Otherwise, we never get the "Begin" input state when Ctrl key is down.
     if (not (UserInputService:IsKeyDown(Enum.KeyCode.LeftControl) or 
         UserInputService:IsKeyDown(Enum.KeyCode.RightControl))) then
+      print("002")
       return
     end
     
+    print("003")
     if actionName ==QUICK_PROFILER_ACTION_NAME then
+      print("004")
       if inputState and inputState == Enum.UserInputState.Begin then
+        print("005")
         GameSettings.PerformanceStatsVisible = not GameSettings.PerformanceStatsVisible
       end
     end

--- a/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
@@ -555,21 +555,16 @@ local function CreateSettingsHub()
   end
 
   local function toggleQuickProfilerFromHotkey(actionName, inputState, inputObject) 
-    print("001")
     -- Make sure it's Ctrl-F7.
     -- NOTE: This will only work if FFlagDontSwallowInputForStudioShortcuts is True.
     -- Otherwise, we never get the "Begin" input state when Ctrl key is down.
     if (not (UserInputService:IsKeyDown(Enum.KeyCode.LeftControl) or 
         UserInputService:IsKeyDown(Enum.KeyCode.RightControl))) then
-      print("002")
       return
     end
     
-    print("003")
     if actionName ==QUICK_PROFILER_ACTION_NAME then
-      print("004")
       if inputState and inputState == Enum.UserInputState.Begin then
-        print("005")
         GameSettings.PerformanceStatsVisible = not GameSettings.PerformanceStatsVisible
       end
     end

--- a/CoreScriptsRoot/Modules/Stats/StatsButton.lua
+++ b/CoreScriptsRoot/Modules/Stats/StatsButton.lua
@@ -64,6 +64,10 @@ function StatsButtonClass:OnVisibilityChanged()
   if self._graph then 
     self._graph:OnVisibilityChanged()
   end
+  
+  if self._textPanel then 
+    self._textPanel:OnVisibilityChanged()
+  end
 end
 
 function StatsButtonClass:SetToggleCallbackFunction(callbackFunction) 

--- a/CoreScriptsRoot/Modules/Stats/StatsViewer.lua
+++ b/CoreScriptsRoot/Modules/Stats/StatsViewer.lua
@@ -51,6 +51,9 @@ function StatsViewerClass:OnVisibilityChanged()
   if self._graph then 
     self._graph:OnVisibilityChanged()
   end
+  if self._textPanel then 
+    self._textPanel:OnVisibilityChanged()
+  end
 end
 
 function StatsViewerClass:GetIsVisible()


### PR DESCRIPTION
Don't update stat numbers in mini buttons or enlarged graph view when the panel is hidden.

Using the same approach as used for graph: when we're hidden stop listening to aggregator.  When unhidden start listening again.