### PR TITLE
Connect to PlayerAdded and PlayerRemoved events on Players

### DIFF
--- a/CoreScriptsRoot/Modules/PlayerDropDown.lua
+++ b/CoreScriptsRoot/Modules/PlayerDropDown.lua
@@ -11,6 +11,9 @@ local HttpService = game:GetService('HttpService')
 local HttpRbxApiService = game:GetService('HttpRbxApiService')
 local PlayersService = game:GetService('Players')
 
+local newBlockFunctionSuccess, newBlockFunctionValue = pcall(function() return settings():GetFFlag("UseNewBlockFunction") end)
+local useNewBlockFunction = (newBlockFunctionSuccess == true and newBlockFunctionValue == true)
+
 --[[ Script Variables ]]--
 local LocalPlayer = PlayersService.LocalPlayer
 
@@ -213,9 +216,15 @@ local function BlockPlayerAsync(playerToBlock)
 			if not isBlocked(blockUserId) then
 				BlockedList[blockUserId] = true
 				BlockStatusChanged:fire(blockUserId, true)
-				pcall(function()
-					local success = LocalPlayer:BlockUser(playerToBlock)
-				end)
+				if not useNewBlockFunction then
+					pcall(function()
+						local success = PlayersService:BlockUser(LocalPlayer.UserId, blockUserId)
+					end)				
+				else
+					pcall(function()
+						local success = LocalPlayer:BlockUser(playerToBlock)
+					end)
+				end
 			end
 		end
 	end
@@ -228,9 +237,15 @@ local function UnblockPlayerAsync(playerToUnblock)
 		if isBlocked(unblockUserId) then
 			BlockedList[unblockUserId] = nil
 			BlockStatusChanged:fire(unblockUserId, false)
-			pcall(function()
-				local success = LocalPlayer:UnblockUser(playerToUnblock)
-			end)
+			if not useNewBlockFunction then
+				pcall(function()
+					local success = PlayersService:UnblockUser(LocalPlayer.UserId, unblockUserId)
+				end)
+			else
+				pcall(function()
+					local success = LocalPlayer:UnblockUser(playerToUnblock)
+				end)
+			end
 		end
 	end
 end

--- a/CoreScriptsRoot/Modules/PlayerDropDown.lua
+++ b/CoreScriptsRoot/Modules/PlayerDropDown.lua
@@ -214,7 +214,7 @@ local function BlockPlayerAsync(playerToBlock)
 				BlockedList[blockUserId] = true
 				BlockStatusChanged:fire(blockUserId, true)
 				pcall(function()
-					local success = PlayersService:BlockUser(LocalPlayer.userId, blockUserId)
+					local success = LocalPlayer:BlockUser(playerToBlock)
 				end)
 			end
 		end
@@ -229,7 +229,7 @@ local function UnblockPlayerAsync(playerToUnblock)
 			BlockedList[unblockUserId] = nil
 			BlockStatusChanged:fire(unblockUserId, false)
 			pcall(function()
-				local success = PlayersService:UnblockUser(LocalPlayer.userId, unblockUserId)
+				local success = LocalPlayer:UnblockUser(playerToUnblock)
 			end)
 		end
 	end

--- a/CoreScriptsRoot/Modules/PlayerlistModule.lua
+++ b/CoreScriptsRoot/Modules/PlayerlistModule.lua
@@ -1490,12 +1490,11 @@ UserInputService.InputBegan:connect(function(inputObject, isProcessed)
 -- NOTE: Core script only
 
 --[[ Player Add/Remove Connections ]]--
-PlayersService.ChildAdded:connect(function(child)
-    if child:IsA('Player') then
-      insertPlayerEntry(child)
-    end
-  end)
-for _,player in pairs(PlayersService:GetPlayers()) do
+PlayersService.PlayerAdded:connect(function(child)
+  insertPlayerEntry(child)
+end)
+
+for _, player in ipairs(PlayersService:GetPlayers()) do
   insertPlayerEntry(player)
 end
 
@@ -1517,13 +1516,11 @@ if not isTenFootInterface then
   end)
 end
 
-PlayersService.ChildRemoved:connect(function(child)
-  if child:IsA('Player') then
-    if LastSelectedPlayer and child == LastSelectedPlayer then
-      playerDropDown:Hide()
-    end
-    removePlayerEntry(child)
+PlayersService.PlayerRemoved:connect(function(child)
+  if LastSelectedPlayer and child == LastSelectedPlayer then
+    playerDropDown:Hide()
   end
+  removePlayerEntry(child)
 end)
 
 --[[ Teams ]]--


### PR DESCRIPTION
This means the player name displayed on the leaderboard will be displayed correctly in Play Solo. 

In Play Solo the player is added to Players and then renamed from Player to Player1, this happens before the PlayerAdded signal is fired. By using the other signal the correct player name will be displayed.