### PR TITLE
Fix for local dialogs

### DIFF
--- a/CoreScriptsRoot/CoreScripts/MainBotChatScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/MainBotChatScript2.lua
@@ -269,6 +269,9 @@ function endDialog()
 	if dialog and dialog.InUse then
 		-- Waits 5 seconds before setting InUse to false
 		setDialogInUseEvent:FireServer(dialog, false, 5)
+		delay(5, function()
+			dialog.InUse = false
+		end)
 	end
 
 	for dialog, gui in pairs(dialogMap) do
@@ -502,6 +505,7 @@ function renewKillswitch(dialog)
 		if thisCoroutine ~= nil then
 			if coroutineMap[thisCoroutine] == nil then
 				setDialogInUseEvent:FireServer(dialog, false, 0)
+				dialog.InUse = false
 			end
 			coroutineMap[thisCoroutine] = nil
 		end


### PR DESCRIPTION
The InUse property isn't set correctly for local dialogs because we are
relying on the dialog being replicated to the server so the server can
set the InUse property. The solution to this is to simply set the InUse
property on the client as well as the server (if the dialog exists)