### PR TITLE
TargetChannel should initialize as a blank string.

### DIFF
--- a/CoreScriptsRoot/Modules/Server/ClientChat/ChatBar.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/ChatBar.lua
@@ -444,7 +444,7 @@ function module.new(CommandProcessor, ChatWindow)
 	obj.InCustomState = false
 	obj.CustomState = nil
 
-	obj.TargetChannel = nil
+	obj.TargetChannel = ""
 	obj.CommandProcessor = CommandProcessor
 	obj.ChatWindow = ChatWindow
 


### PR DESCRIPTION
The ClassMaker module thinks that TargetChannel isn't a valid property before it gets set, which results in the chat getting spammed with errors when typing into the chat bar before it gets set. Setting it to a blank string fixes this problem.

This issue only happens if ShowChannelsBar is set to true in the ChatSettings.