### PR TITLE
Fix following icon

### DIFF
--- a/CoreScriptsRoot/Modules/PlayerlistModule.lua
+++ b/CoreScriptsRoot/Modules/PlayerlistModule.lua
@@ -832,12 +832,14 @@ local function setFollowRelationshipsView(relationshipTable)
         icon = FOLLOWER_ICON
       end
     end
-
-    local frame = entry.Frame
-    local bgFrame = frame:FindFirstChild('BGFrame')
-    if bgFrame then
-      updateSocialIcon(icon, bgFrame)
-    end
+	
+	if icon then
+		local frame = entry.Frame
+		local bgFrame = frame:FindFirstChild('BGFrame')
+		if bgFrame then
+		  updateSocialIcon(icon, bgFrame)
+		end
+	end
   end
 end
 


### PR DESCRIPTION
Fix all following status icons being overridden when a new player joins the game. This happens because the following status of a new player is sent in the same format as the initial data. Thus, the script incorrectly attempts to set all existing players' icons to nil because no data is sent for already existing players.