### PR TITLE
CLIXBOX-1053 - Remove RequestGameShutdown in favor of game:Shutdown

### DIFF
--- a/CoreScriptsRoot/LoadingScript.lua
+++ b/CoreScriptsRoot/LoadingScript.lua
@@ -199,30 +199,22 @@ local function createTenfootCancelGui()
 		Text = "Cancel";
 	}
 
-	-- bind cancel action
-	local platformService = nil
-	pcall(function()
-		platformService = game:GetService('PlatformService')
-	end)
-
-	if platformService then
-		if not game:GetService("ReplicatedFirst"):IsFinishedReplicating() then
-			local seenBButtonBegin = false
-			ContextActionService:BindCoreAction("CancelGameLoad",
-				function(actionName, inputState, inputObject)
-					if inputState == Enum.UserInputState.Begin then
-						seenBButtonBegin = true
-					elseif inputState == Enum.UserInputState.End and seenBButtonBegin then
-						cancelLabel:Destroy()
-						cancelText.Text = "Canceling..."
-						cancelText.Position = UDim2.new(1, -32, 0, 64)
-						ContextActionService:UnbindCoreAction('CancelGameLoad')
-						platformService:RequestGameShutdown()
-					end
-				end,
-				false,
-				Enum.KeyCode.ButtonB)
-		end
+	if not game:GetService("ReplicatedFirst"):IsFinishedReplicating() then
+		local seenBButtonBegin = false
+		ContextActionService:BindCoreAction("CancelGameLoad",
+			function(actionName, inputState, inputObject)
+				if inputState == Enum.UserInputState.Begin then
+					seenBButtonBegin = true
+				elseif inputState == Enum.UserInputState.End and seenBButtonBegin then
+					cancelLabel:Destroy()
+					cancelText.Text = "Canceling..."
+					cancelText.Position = UDim2.new(1, -32, 0, 64)
+					ContextActionService:UnbindCoreAction('CancelGameLoad')
+					game:Shutdown()
+				end
+			end,
+			false,
+			Enum.KeyCode.ButtonB)
 	end
 
 	while cancelLabel.Parent == nil do


### PR DESCRIPTION
No longer need to call this platformService:RequestGameShutdown(), as game:Shutdown() will invoke the exit verb. Xbox overrides the verb to handle game shut down correctly on Xbox. This change is also needed to fix CLIXBOX-1017.