### PR TITLE
MasterControl modified so that JumpRequest fires once

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl.rbxmx
@@ -63,7 +63,10 @@ function MasterControl:Init()
 			if not humanoid then return end
 			
 			if humanoid and not humanoid.PlatformStand and isJumping then
-				humanoid.Jump = isJumping
+				local state = humanoid:GetState()
+				if state ~= Enum.HumanoidStateType.Jumping and state ~= Enum.HumanoidStateType.Freefall and state ~= Enum.HumanoidStateType.Landed then
+					humanoid.Jump = isJumping
+				end
 			end
 			
 			local adjustedMoveValue = moveValue
@@ -111,6 +114,10 @@ end
 
 function MasterControl:SetIsJumping(jumping)
 	isJumping = jumping
+	local humanoid = self:GetHumanoid()
+	if humanoid and not humanoid.PlatformStand then
+		humanoid.Jump = isJumping
+	end
 end
 
 function MasterControl:DoJump()

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbpad.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbpad.rbxmx
@@ -181,6 +181,8 @@ function Thumbpad:Create(parentFrame)
 	
 	--input connections
 	ThumbpadFrame.InputBegan:connect(function(inputObject)
+		--A touch that starts elsewhere on the screen will be sent to a frame's InputBegan event
+		--if it moves over the frame. So we check that this is actually a new touch (inputObject.UserInputState ~= Enum.UserInputState.Begin)
 		if TouchObject or inputObject.UserInputType ~= Enum.UserInputType.Touch
 			or inputObject.UserInputState ~= Enum.UserInputState.Begin then
 			return

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbpad.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbpad.rbxmx
@@ -181,7 +181,8 @@ function Thumbpad:Create(parentFrame)
 	
 	--input connections
 	ThumbpadFrame.InputBegan:connect(function(inputObject)
-		if TouchObject or inputObject.UserInputType ~= Enum.UserInputType.Touch then
+		if TouchObject or inputObject.UserInputType ~= Enum.UserInputType.Touch
+			or inputObject.UserInputState ~= Enum.UserInputState.Begin then
 			return
 		end
 		

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
@@ -132,7 +132,8 @@ function Thumbstick:Create(parentFrame)
 	
 	-- input connections
 	ThumbstickFrame.InputBegan:connect(function(inputObject)
-		if MoveTouchObject or inputObject.UserInputType ~= Enum.UserInputType.Touch then
+		if MoveTouchObject or inputObject.UserInputType ~= Enum.UserInputType.Touch
+			or inputObject.UserInputState ~= Enum.UserInputState.Begin then
 			return
 		end
 		

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/Thumbstick.rbxmx
@@ -132,6 +132,8 @@ function Thumbstick:Create(parentFrame)
 	
 	-- input connections
 	ThumbstickFrame.InputBegan:connect(function(inputObject)
+		--A touch that starts elsewhere on the screen will be sent to a frame's InputBegan event
+		--if it moves over the frame. So we check that this is actually a new touch (inputObject.UserInputState ~= Enum.UserInputState.Begin)
 		if MoveTouchObject or inputObject.UserInputType ~= Enum.UserInputType.Touch
 			or inputObject.UserInputState ~= Enum.UserInputState.Begin then
 			return

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
@@ -147,7 +147,8 @@ function TouchJump:Create(parentFrame)
 	
 	local touchObject = nil	
 	JumpButton.InputBegan:connect(function(inputObject)
-		if touchObject or inputObject.UserInputType ~= Enum.UserInputType.Touch then
+		if touchObject or inputObject.UserInputType ~= Enum.UserInputType.Touch
+			or inputObject.UserInputState ~= Enum.UserInputState.Begin then
 			return
 		end
 		

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/TouchJump.rbxmx
@@ -147,6 +147,8 @@ function TouchJump:Create(parentFrame)
 	
 	local touchObject = nil	
 	JumpButton.InputBegan:connect(function(inputObject)
+		--A touch that starts elsewhere on the screen will be sent to a frame's InputBegan event
+		--if it moves over the frame. So we check that this is actually a new touch (inputObject.UserInputState ~= Enum.UserInputState.Begin)
 		if touchObject or inputObject.UserInputType ~= Enum.UserInputType.Touch
 			or inputObject.UserInputState ~= Enum.UserInputState.Begin then
 			return


### PR DESCRIPTION
Because Humanoid.Jump was being set on each RenderStep, and because the engine changes Jump from true to false when a jump can't occur, the Humanoid.Jump value was toggling back and forth from true to false 2 or 3 times on each jump, which made the JumpRequest signal (which fires when jump becomes true) difficult for developers to use.

So checks are added here on Humanoid:GetState() to make sure a jump can occur, in addition to setting Humanoid.Jump when SetIsJumping is called by the MasterControl submodules.
