### PR TITLE
New Chat restrict bubble chat to specific types of message.

### DIFF
--- a/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/ChatSettings.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/ChatSettings.lua
@@ -4,6 +4,9 @@
 
 local PlayersService = game:GetService("Players")
 
+local clientChatModules = script.Parent
+local ChatConstants = require(clientChatModules:WaitForChild("ChatConstants"))
+
 local module = {}
 
 ---[[ Chat Behaviour Settings ]]
@@ -77,6 +80,7 @@ module.MaximumMessageLength = 200
 module.DisallowedWhiteSpace = {"\n", "\r", "\t", "\v", "\f"}
 module.ClickOnPlayerNameToWhisper = true
 module.ClickOnChannelNameToSetMainChannel = true
+module.BubbleChatMessageTypes = {ChatConstants.MessageTypeDefault, ChatConstants.MessageTypeWhisper}
 
 ---[[ Misc Settings ]]
 module.WhisperCommandAutoCompletePlayerNames = true


### PR DESCRIPTION
Don't show /me commands in bubble chat for now. We might get a different design for these and show them in bubble chat at some point in the future.