### PR TITLE
Harden remote events against bad input

### DIFF
--- a/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
@@ -450,7 +450,6 @@ local function onSendNotificationInfo(notificationInfo)
 	--Right now, calling sendNotification(...) will essentially translate into a sendNotificationInfo(table), which will then be translated back
 	--into a parameter list here. One option in the future is to update the code that produces the notification in non-VR to use notificationInfo table.
 	onSendNotification(notificationInfo.Title, notificationInfo.Text, notificationInfo.Image, notificationInfo.Duration, notificationInfo.Callback, notificationInfo.Button1Text, notificationInfo.Button2Text)
-	onSendNotification(notificationInfo.Title, notificationInfo.Text, notificationInfo.Image, notificationInfo.Duration, notificationInfo.Callback, notificationInfo.Button1Text, notificationInfo.Button2Text)
 end
 BindableEvent_SendNotificationInfo.Event:connect(onSendNotificationInfo)
 

--- a/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
@@ -450,6 +450,7 @@ local function onSendNotificationInfo(notificationInfo)
 	--Right now, calling sendNotification(...) will essentially translate into a sendNotificationInfo(table), which will then be translated back
 	--into a parameter list here. One option in the future is to update the code that produces the notification in non-VR to use notificationInfo table.
 	onSendNotification(notificationInfo.Title, notificationInfo.Text, notificationInfo.Image, notificationInfo.Duration, notificationInfo.Callback, notificationInfo.Button1Text, notificationInfo.Button2Text)
+	onSendNotification(notificationInfo.Title, notificationInfo.Text, notificationInfo.Image, notificationInfo.Duration, notificationInfo.Callback, notificationInfo.Button1Text, notificationInfo.Button2Text)
 end
 BindableEvent_SendNotificationInfo.Event:connect(onSendNotificationInfo)
 
@@ -791,7 +792,7 @@ local function createDeveloperNotification(notificationTable)
 		if type(notificationTable.Title) == "string" and type(notificationTable.Text) == "string" then
 			local iconImage = (type(notificationTable.Icon) == "string" and notificationTable.Icon or "")
 			local duration = (type(notificationTable.Duration) == "number" and notificationTable.Duration or DEFAULT_NOTIFICATION_DURATION)
-			local success, bindable = pcall(function() return (notificationTable.Callback:IsA("BindableFunction") and notificationTable.Callback or nil) end)
+			local bindable = (typeof(notificationTable.Callback) == "Instance" and notificationTable.Callback:IsA("BindableFunction") and notificationTable.Callback or nil)
 			local button1Text = (type(notificationTable.Button1) == "string" and notificationTable.Button1 or "")
 			local button2Text = (type(notificationTable.Button2) == "string" and notificationTable.Button2 or "")
 			if newNotificationPath then

--- a/CoreScriptsRoot/Modules/Chat.lua
+++ b/CoreScriptsRoot/Modules/Chat.lua
@@ -1849,20 +1849,14 @@ local function CreateChatWindowWidget(settings)
     local settings = shallowCopy(this.Settings)
 
     if informationTable["Text"] and type(informationTable["Text"]) == "string" then
-      if informationTable["Color"] and pcall(function() Color3.new(informationTable["Color"].r, informationTable["Color"].g, informationTable["Color"].b) end) then
-        settings.DefaultMessageTextColor = informationTable["Color"]
+      if typeof(informationTable.Color) == "Color3" then
+        settings.DefaultMessageTextColor = informationTable.Color
       end
-      if informationTable["Font"] then
-        local success, value = pcall(function() return checkEnum(Enum.Font:GetEnumItems(), informationTable["Font"].Value) end)
-        if success and value ~= nil then
-          settings.Font = value
-        end
+      if typeof(informationTable.Font) == "EnumItem" and informationTable.Font.EnumType == Enum.Font then
+        settings.Font = informationTable.Font
       end
-      if informationTable["FontSize"] then
-        local success, value = pcall(function() return checkEnum(Enum.FontSize:GetEnumItems(), informationTable["FontSize"].Value) end)
-        if success and value ~= nil then
-          settings.FontSize = value
-        end
+      if typeof(informationTable.FontSize) == "EnumItem" and informationTable.FontSize.EnumType == Enum.FontSize then
+        settings.FontSize = informationTable.FontSize
       end
       local chatMessage = CreateSystemChatMessage(settings, informationTable["Text"])
       this:PushMessageIntoQueue(chatMessage, false)
@@ -2685,8 +2679,7 @@ local function CreateChat()
           end
         end)
       local function isUDim2Value(value)
-        local success, value = pcall(function() return UDim2.new(value.X.Scale, value.X.Offset, value.Y.Scale, value.Y.Offset) end)
-        return success and value or nil
+        return typeof(value) == "UDim2" and value or nil
       end
 
       local function isBubbleChatOn()

--- a/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
@@ -229,16 +229,12 @@ local function CreateSettingsHub()
 
 	if resetButtonCustomizationAllowed then
 		StarterGui:RegisterSetCore("ResetButtonCallback", function(callback)
-			local isBindableSuccess, isBindableValue = pcall(function() return type(callback) == "userdata" and callback:IsA("BindableEvent") end)
-			local isBindable = (isBindableSuccess and isBindableValue)
-			if isBindable or type(callback) == "boolean" then
 				this.ResetCharacterPage:SetResetCallback(callback)
 			else
 				warn("ResetButtonCallback must be set to a BindableEvent or a boolean")
 			end
 			if callback == false then
 				setResetEnabled(false)
-			elseif not resetEnabled and (isBindable or callback == true) then
 				setResetEnabled(true)
 			end
 		end)

--- a/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
@@ -229,6 +229,8 @@ local function CreateSettingsHub()
 
 	if resetButtonCustomizationAllowed then
 		StarterGui:RegisterSetCore("ResetButtonCallback", function(callback)
+			local isBindableEvent = typeof(callback) == "Instance" and callback:IsA("BindableEvent")
+			if isBindableEvent or type(callback) == "boolean" then
 				this.ResetCharacterPage:SetResetCallback(callback)
 			else
 				warn("ResetButtonCallback must be set to a BindableEvent or a boolean")

--- a/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
@@ -237,6 +237,7 @@ local function CreateSettingsHub()
 			end
 			if callback == false then
 				setResetEnabled(false)
+			elseif not resetEnabled and (isBindableEvent or callback == true) then
 				setResetEnabled(true)
 			end
 		end)

--- a/CoreScriptsRoot/ServerCoreScripts/ServerSocialScript.lua
+++ b/CoreScriptsRoot/ServerCoreScripts/ServerSocialScript.lua
@@ -158,9 +158,13 @@ end
 -- Map: { UserId -> { UserId -> NumberOfNotificationsSent } }
 local FollowNotificationsBetweenMap = {}
 
+local function isPlayer(value)
+	return typeof(value) == "Instance" and value:IsA("Player")
+end
+
 -- client fires event to server on new follow
 RemoteEvent_NewFollower.OnServerEvent:connect(function(player1, player2, player1FollowsPlayer2)
-	if player1 == nil or player2 == nil or player1FollowsPlayer2 == nil then
+	if not isPlayer(player1) or not isPlayer(player2) or type(player1FollowsPlayer2) ~= "boolean" then
 		return
 	end
 

--- a/CoreScriptsRoot/ServerStarterScript.lua
+++ b/CoreScriptsRoot/ServerStarterScript.lua
@@ -30,6 +30,16 @@ local dialogInUseFixFlagSuccess, dialogInUseFixValue = pcall(function() return s
 local dialogInUseFixFlag = (dialogInUseFixFlagSuccess and dialogInUseFixValue)
 
 local function setDialogInUse(player, dialog, value, waitTime)
+	if typeof(dialog) ~= "Instance" or not dialog:IsA("Dialog") then
+		return
+	end
+	if type(value) ~= "boolean" then
+		return
+	end
+	if type(waitTime) ~= "number" and type(waitTime) ~= "nil" then
+		return
+	end
+
 	if waitTime and waitTime ~= 0 then
 		wait(waitTime)
 	end


### PR DESCRIPTION
* Use typeof(value) instead of pcalling to determine userdata type
* Perform type checks on arguments supplied by clients