### PR TITLE
New Chat: Fix /team showing unfiltered text to the user who had entered it.

### DIFF
--- a/CoreScriptsRoot/Modules/Server/ServerChat/ChatChannel.lua
+++ b/CoreScriptsRoot/Modules/Server/ServerChat/ChatChannel.lua
@@ -65,18 +65,17 @@ function methods:SendMessageToSpeaker(message, speakerName, fromSpeaker, extraDa
 			return
 		end
 
+		-- We need to claim the message is filted even if it not in this case for compatibility with legacy client side code.
 		local isFiltered = speakerName == fromSpeaker
 		local messageObj = self:InternalCreateMessageObject(message, fromSpeaker, isFiltered, extraData)
 		message = self:SendMessageObjToFilters(message, messageObj, fromSpeaker)
 		speaker:InternalSendMessage(messageObj, self.Name)
 
-		if not isFiltered then
-			local filteredMessage = self.ChatService:InternalApplyRobloxFilter(messageObj.FromSpeaker, message, speakerName)
-			if filteredMessage then
-				messageObj.Message = filteredMessage
-				messageObj.IsFiltered = true
-				speaker:InternalSendFilteredMessage(messageObj, self.Name)
-			end
+		local filteredMessage = self.ChatService:InternalApplyRobloxFilter(messageObj.FromSpeaker, message, speakerName)
+		if filteredMessage then
+			messageObj.Message = filteredMessage
+			messageObj.IsFiltered = true
+			speaker:InternalSendFilteredMessage(messageObj, self.Name)
 		end
 	else
 		warn(string.format("Speaker '%s' is not in channel '%s' and cannot be sent a message", speakerName, self.Name))
@@ -266,6 +265,7 @@ function methods:InternalPostMessage(fromSpeaker, message, extraData)
 				local cMessageObj = DeepCopy(messageObj)
 				cMessageObj.Message = message
 				cMessageObj.IsFiltered = true
+				-- We need to claim the message is filted even if it not in this case for compatibility with legacy client side code.
 				speaker:InternalSendMessage(cMessageObj, self.Name)
 			else
 				speaker:InternalSendMessage(messageObj, self.Name)

--- a/CoreScriptsRoot/Modules/Server/ServerChat/ChatChannel.lua
+++ b/CoreScriptsRoot/Modules/Server/ServerChat/ChatChannel.lua
@@ -65,7 +65,7 @@ function methods:SendMessageToSpeaker(message, speakerName, fromSpeaker, extraDa
 			return
 		end
 
-		-- We need to claim the message is filted even if it not in this case for compatibility with legacy client side code.
+		-- We need to claim the message is filtered even if it not in this case for compatibility with legacy client side code.
 		local isFiltered = speakerName == fromSpeaker
 		local messageObj = self:InternalCreateMessageObject(message, fromSpeaker, isFiltered, extraData)
 		message = self:SendMessageObjToFilters(message, messageObj, fromSpeaker)
@@ -265,7 +265,7 @@ function methods:InternalPostMessage(fromSpeaker, message, extraData)
 				local cMessageObj = DeepCopy(messageObj)
 				cMessageObj.Message = message
 				cMessageObj.IsFiltered = true
-				-- We need to claim the message is filted even if it not in this case for compatibility with legacy client side code.
+				-- We need to claim the message is filtered even if it not in this case for compatibility with legacy client side code.
 				speaker:InternalSendMessage(cMessageObj, self.Name)
 			else
 				speaker:InternalSendMessage(messageObj, self.Name)


### PR DESCRIPTION
This also fixes a bubble chat issue where it would not correctly display message from /w or /team for the user who had entered the message.

Basically in this case we are sending the unfiltered message for the user who had entered it but pretending it is filtered. We can't change this behaviour even if it is not ideal because it will break legacy client side partial chat copies. 

We should always still send the filtered text because the client might want to display that instead, so a user can see what parts of their message was filtered.