### PR TITLE
Improve PurchasePromptScript Error Message

### DIFF
--- a/CoreScriptsRoot/CoreScripts/PurchasePromptScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/PurchasePromptScript2.lua
@@ -908,7 +908,7 @@ local function getProductInfo()
 	end
 
 	if not success or not result then
-		print("PurchasePromptScript: getProductInfo failed because", result)
+		warn("PurchasePromptScript: getProductInfo failed because", result, "Make sure a valid ID was specified")
 		return nil
 	end
 
@@ -1053,7 +1053,7 @@ local function canPurchase(disableUpsell)
 			return false
 		end
 	else
-		if game.Players.LocalPlayer.UserId < 0 then
+		if Players.LocalPlayer.UserId < 0 then
 			onPurchaseFailed(PURCHASE_FAILED.PROMPT_PURCHASE_ON_GUEST)
 			return false
 		end
@@ -1079,7 +1079,7 @@ local function canPurchase(disableUpsell)
 
 	PurchaseData.ProductInfo = getProductInfo()
 	if not PurchaseData.ProductInfo then
-		onPurchaseFailed(PURCHASE_FAILED.IN_GAME_PURCHASE_DISABLED)
+		onPurchaseFailed(PURCHASE_FAILED.DEFAULT_ERROR)
 		return false
 	end
 

--- a/CoreScriptsRoot/CoreScripts/PurchasePromptScript3.lua
+++ b/CoreScriptsRoot/CoreScripts/PurchasePromptScript3.lua
@@ -1015,7 +1015,7 @@ local function getProductInfo()
 	end
 
 	if not success or not result then
-		print("PurchasePromptScript: getProductInfo failed because", result)
+		warn("PurchasePromptScript: getProductInfo failed because", result, "Make sure a valid ID was specified")
 		return nil
 	end
 
@@ -1171,7 +1171,7 @@ local function canPurchase(disableUpsell)
 
 	PurchaseData.ProductInfo = getProductInfo()
 	if not PurchaseData.ProductInfo then
-		onPurchaseFailed(PURCHASE_FAILED.IN_GAME_PURCHASE_DISABLED)
+		onPurchaseFailed(PURCHASE_FAILED.DEFAULT_ERROR)
 		return false
 	end
 


### PR DESCRIPTION
Use DEFAULT_ERROR instead of IN_GAME_PURCHASE_DISABLED if getProductInfo() fails. The current behavior is confusing because it does not distinguish between getProductInfo() failing because the marketplace is down/disabled or getProductInfo() failing because an invalid ID was specified.

Also fix missed case of game:GetService() instead of indexing the service directly, and improve warn message given when getProductInfo() fails.