### PR TITLE
Chat: Fix memory leak.

### DIFF
--- a/CoreScriptsRoot/Modules/Server/ServerChat/ChatChannel.lua
+++ b/CoreScriptsRoot/Modules/Server/ServerChat/ChatChannel.lua
@@ -205,6 +205,13 @@ function methods:InternalDestroy()
 	end
 
 	self.eDestroyed:Fire()
+
+	self.eDestroyed:Destroy()
+	self.eMessagePosted:Destroy()
+	self.eSpeakerJoined:Destroy()
+	self.eSpeakerLeft:Destroy()
+	self.eSpeakerMuted:Destroy()
+	self.eSpeakerUnmuted:Destroy()
 end
 
 function methods:InternalDoMessageFilter(speakerName, messageObj, channel)
@@ -452,15 +459,12 @@ function module.new(vChatService, name, welcomeMessage, channelNameColor)
 	obj.MaxHistory = 200
 	obj.HistoryIndex = 0
 	obj.ChatHistory = {}
-	obj.MessageQueue = {}
-	obj.InternalMessageQueueChanged = Instance.new("BindableEvent")
 
 	obj.FilterMessageFunctions = Util:NewSortedFunctionContainer()
 	obj.ProcessCommandsFunctions = Util:NewSortedFunctionContainer()
 
+	-- Make sure to destroy added binadable events in the InternalDestroy method.
 	obj.eDestroyed = Instance.new("BindableEvent")
-	obj.Destroyed = obj.eDestroyed.Event
-
 	obj.eMessagePosted = Instance.new("BindableEvent")
 	obj.eSpeakerJoined = Instance.new("BindableEvent")
 	obj.eSpeakerLeft = Instance.new("BindableEvent")
@@ -472,6 +476,7 @@ function module.new(vChatService, name, welcomeMessage, channelNameColor)
 	obj.SpeakerLeft = obj.eSpeakerLeft.Event
 	obj.SpeakerMuted = obj.eSpeakerMuted.Event
 	obj.SpeakerUnmuted = obj.eSpeakerUnmuted.Event
+	obj.Destroyed = obj.eDestroyed.Event
 
 	return obj
 end

--- a/CoreScriptsRoot/Modules/Server/ServerChat/ChatService.lua
+++ b/CoreScriptsRoot/Modules/Server/ServerChat/ChatService.lua
@@ -110,9 +110,18 @@ function methods:AddSpeaker(speakerName)
 	return speaker
 end
 
+function methods:InternalUnmuteSpeaker(speakerName)
+	for channelName, channel in pairs(self.ChatChannels) do
+		if channel:IsSpeakerMuted(speakerName) then
+			channel:UnmuteSpeaker(speakerName)
+		end
+	end
+end
+
 function methods:RemoveSpeaker(speakerName)
 	if (self.Speakers[speakerName:lower()]) then
 		local n = self.Speakers[speakerName:lower()].Name
+		self:InternalUnmuteSpeaker(n)
 
 		self.Speakers[speakerName:lower()]:InternalDestroy()
 		self.Speakers[speakerName:lower()] = nil

--- a/CoreScriptsRoot/Modules/Server/ServerChat/Speaker.lua
+++ b/CoreScriptsRoot/Modules/Server/ServerChat/Speaker.lua
@@ -145,6 +145,19 @@ function methods:InternalDestroy()
 	end
 
 	self.eDestroyed:Fire()
+
+	self.eDestroyed:Destroy()
+	self.eSaidMessage:Destroy()
+	self.eReceivedMessage:Destroy()
+	self.eMessageDoneFiltering:Destroy()
+	self.eReceivedSystemMessage:Destroy()
+	self.eChannelJoined:Destroy()
+	self.eChannelLeft:Destroy()
+	self.eMuted:Destroy()
+	self.eUnmuted:Destroy()
+	self.eExtraDataUpdated:Destroy()
+	self.eMainChannelSet:Destroy()
+	self.eChannelNameColorUpdated:Destroy()
 end
 
 function methods:InternalAssignPlayerObject(playerObj)
@@ -198,9 +211,8 @@ function module.new(vChatService, name)
 	obj.Channels = {}
 	obj.MutedSpeakers = {}
 
+	-- Make sure to destroy added binadable events in the InternalDestroy method.
 	obj.eDestroyed = Instance.new("BindableEvent")
-	obj.Destroyed = obj.eDestroyed.Event
-
 	obj.eSaidMessage = Instance.new("BindableEvent")
 	obj.eReceivedMessage = Instance.new("BindableEvent")
 	obj.eMessageDoneFiltering = Instance.new("BindableEvent")
@@ -213,6 +225,7 @@ function module.new(vChatService, name)
 	obj.eMainChannelSet = Instance.new("BindableEvent")
 	obj.eChannelNameColorUpdated = Instance.new("BindableEvent")
 
+	obj.Destroyed = obj.eDestroyed.Event
 	obj.SaidMessage = obj.eSaidMessage.Event
 	obj.ReceivedMessage = obj.eReceivedMessage.Event
 	obj.MessageDoneFiltering = obj.eMessageDoneFiltering.Event


### PR DESCRIPTION
We need to destroy the created BindableEvents to make sure that an object is not kept around because these are connected to.

We also need to disconnect the connection to the Player.Changed event, because otherwise this will leak memory. 