### PR TITLE
Add CoreScript option "AddOption" to add custom settings.

### DIFF
--- a/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
@@ -331,6 +331,18 @@ local function Initialize()
         return
       end
 
+      if option[3] > 10 then
+        warn("The third entry of AddOption can't be greater than 10, setting it to 10.")
+
+        option[3] = 10
+      end
+
+      if option[3] < 1 then
+        warn("The third entry of AddOption can't be less than 1, setting it to 1.")
+
+        option[3] = 1
+      end
+
       _, __, customRow = utility:AddNewRow(this,
                   option[1],
                   "Slider",

--- a/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
@@ -61,6 +61,7 @@ local PageInstance = nil
 local LocalPlayer = Players.LocalPlayer
 local platform = UserInputService:GetPlatform()
 local overscanScreen = nil
+local customOptions = {}
 
 ----------- CLASS DECLARATION --------------
 
@@ -288,6 +289,78 @@ local function Initialize()
         end
       end)
   end  -- of createPerformanceStats
+
+  ----------- CUSTOM OPTIONS ---------
+  StarterGui:RegisterSetCore("AddOption", function(option)
+    if typeof(option) ~= "table" then
+      warn("AddOption must have a table")
+      return
+    end
+
+    if #option ~= 4 then
+      warn("AddOption length isn't 4")
+      return
+    end
+
+    --TODO: Instead of strings, this should use Enums. However, CoreScripts can't set an Enum, only Roblox (with C) can.
+    if typeof(option[1]) ~= "string" then
+      warn("The first entry of AddOption must be a string")
+      return
+    end
+
+    if typeof(option[2]) ~= "string" then
+      warn("The second entry of AddOption must be a string")
+      return
+    end
+
+    if option[2] == "Slider" then
+      if typeof(option[3]) ~= "number" or option[3] < 2 then
+        warn("The third entry of AddOption must be a number greater than 2 for sliders.")
+        return
+      end
+
+      if typeof(option[4]) ~= "number" or option[4] > option[3] then
+        warn("The fourth entry of AddOption must be a number less than or equal to that of the third entry for sliders.")
+        return
+      end
+
+      utility:AddNewRow(this,
+        option[1],
+        "Slider",
+        option[3],
+        option[4])
+    elseif option[2] == "Selector" or option[2] == "DropDown" then
+      if typeof(option[3]) ~= "table" then
+        warn("The third entry of AddOption must be a table of values for Selectors and Dropdowns.")
+        return
+      end
+
+      if typeof(option[4]) ~= "number" or option[4] > #option[3] then
+        warn("The fourth entry of AddOption must be a number less than the length of the table of values.")
+        return
+      end
+
+      utility:AddNewRow(this,
+        option[1],
+        option[2],
+        option[3],
+        option[4])
+    elseif option[2] == "TextBox" then
+      --TODO: should we allow this?
+
+      warn("You cannot create TextBoxes with AddOption.")
+      return
+    else
+      warn("Invalid option type "..tostring(option[2]))
+      return
+    end
+
+    table.insert(customOptions, option)
+  end)
+
+  StarterGui:RegisterGetCore("AddOption", function()
+    return customOptions
+  end)
 
   local function createCameraModeOptions(movementModeEnabled)
     ------------------------------------------------------

--- a/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
@@ -297,8 +297,8 @@ local function Initialize()
       return
     end
 
-    if #option ~= 4 then
-      warn("AddOption length isn't 4")
+    if #option ~= 5 then
+      warn("AddOption length isn't 5")
       return
     end
 
@@ -313,6 +313,13 @@ local function Initialize()
       return
     end
 
+    if typeof(option[5]) ~= "Instance" or not option[5]:IsA("BindableEvent") then
+      warn("The fifth entry of AddOption must be a BindableEvent")
+      return
+    end
+
+    local customRow
+
     if option[2] == "Slider" then
       if typeof(option[3]) ~= "number" or option[3] < 2 then
         warn("The third entry of AddOption must be a number greater than 2 for sliders.")
@@ -324,11 +331,15 @@ local function Initialize()
         return
       end
 
-      utility:AddNewRow(this,
-        option[1],
-        "Slider",
-        option[3],
-        option[4])
+      _, __, customRow = utility:AddNewRow(this,
+                  option[1],
+                  "Slider",
+                  option[3],
+                  option[4])
+
+      customRow.ValueChanged:connect(function(val)
+        option[5]:Fire(val)
+      end)
     elseif option[2] == "Selector" or option[2] == "DropDown" then
       if typeof(option[3]) ~= "table" then
         warn("The third entry of AddOption must be a table of values for Selectors and Dropdowns.")
@@ -340,11 +351,15 @@ local function Initialize()
         return
       end
 
-      utility:AddNewRow(this,
-        option[1],
-        option[2],
-        option[3],
-        option[4])
+      _, __, customRow = utility:AddNewRow(this,
+                  option[1],
+                  option[2],
+                  option[3],
+                  option[4])
+
+      customRow.IndexChanged:connect(function(val)
+        option[5]:Fire(val)
+      end)
     elseif option[2] == "TextBox" then
       --TODO: should we allow this?
 
@@ -355,7 +370,7 @@ local function Initialize()
       return
     end
 
-    table.insert(customOptions, option)
+    table.insert(customOptions, customRow)
   end)
 
   StarterGui:RegisterGetCore("AddOption", function()


### PR DESCRIPTION
If you modify your CoreScripts for Roblox Studio and open up this place in Edit Mode, you can test this out now. It's not copy locked.

https://www.roblox.com/games/672801155/roblox-testing-zone

```
local printEvent = Instance.new("BindableEvent")
printEvent.Event:connect(print)

game.StarterGui:SetCore("AddOption", {
	"Test Slider",
	"Slider",
	10,
	5,
	printEvent
})

game.StarterGui:SetCore("AddOption", {
	"Test Selector",
	"Selector",
	{"Foo", "Bar", "Baz"},
	2,
	printEvent
})

game.StarterGui:SetCore("AddOption", {
	"Test Dropdown",
	"DropDown",
	{"Foo", "Bar", "Baz"},
	2,
	printEvent
})
```

![Demo](https://cdn.discordapp.com/attachments/213930516653670400/285639650477867008/unknown.png)