### PR TITLE
Remove Lua implementation of GetTextSize and instead use TextService:GetTextSize()

### DIFF
--- a/CoreScriptsRoot/Modules/Server/ClientChat/BubbleChat/BubbleChat.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/BubbleChat/BubbleChat.lua
@@ -8,6 +8,7 @@
 local PlayersService = game:GetService('Players')
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local ChatService = game:GetService("Chat")
+local TextService = game:GetService("TextService")
 --[[ END OF SERVICES ]]
 
 local LocalPlayer = PlayersService.LocalPlayer
@@ -54,41 +55,7 @@ BubbleChatScreenGui.Name = "BubbleChat"
 BubbleChatScreenGui.ResetOnSpawn = false
 BubbleChatScreenGui.Parent = PlayerGui
 
-local testLabel = Instance.new("TextLabel")
-testLabel.Selectable = false
-testLabel.TextWrapped = true
-testLabel.Position = UDim2.new(1, 0, 1, 0)
-testLabel.Parent = BubbleChatScreenGui
-
-local TextSizeCache = {}
-
 --[[ FUNCTIONS ]]
-
-local function getStringTextBounds(text, font, textSize, sizeBounds)
-	sizeBounds = sizeBounds or false
-	if not TextSizeCache[text] then
-		TextSizeCache[text] = {}
-	end
-	if not TextSizeCache[text][font] then
-		TextSizeCache[text][font] = {}
-	end
-	if not TextSizeCache[text][font][sizeBounds] then
-		TextSizeCache[text][font][sizeBounds] = {}
-	end
-	if not TextSizeCache[text][font][sizeBounds][textSize] then
-		testLabel.Text = text
-		testLabel.Font = font
-		testLabel.TextSize = textSize
-		if sizeBounds then
-			testLabel.TextWrapped = true;
-			testLabel.Size = UDim2.new(0, sizeBounds.x, 0, sizeBounds.y)
-		else
-			testLabel.TextWrapped = false;
-		end
-		TextSizeCache[text][font][sizeBounds][textSize] = testLabel.TextBounds
-	end
-	return TextSizeCache[text][font][sizeBounds][textSize]
-end
 
 local function lerpLength(msg, min, max)
 	return min + (max-min) * math.min(string.len(msg)/75.0, 1.0)
@@ -547,11 +514,11 @@ function this:CreateChatLineRender(instance, line, onlyCharacter, fifo)
 
 		line.RenderBubble = chatBubbleRender
 
-		local currentTextBounds = getStringTextBounds(bubbleText.Text, CHAT_BUBBLE_FONT,
-																									CHAT_BUBBLE_FONT_SIZE_INT,
-																									Vector2.new(BILLBOARD_MAX_WIDTH, BILLBOARD_MAX_HEIGHT))
-		local bubbleWidthScale = math.max((currentTextBounds.x + CHAT_BUBBLE_WIDTH_PADDING)/BILLBOARD_MAX_WIDTH, 0.1)
-		local numOflines = (currentTextBounds.y/CHAT_BUBBLE_FONT_SIZE_INT)
+		local currentTextBounds = TextService:GetTextSize(
+				bubbleText.Text, CHAT_BUBBLE_FONT_SIZE_INT, CHAT_BUBBLE_FONT,
+				Vector2.new(BILLBOARD_MAX_WIDTH, BILLBOARD_MAX_HEIGHT))
+		local bubbleWidthScale = math.max((currentTextBounds.X + CHAT_BUBBLE_WIDTH_PADDING)/BILLBOARD_MAX_WIDTH, 0.1)
+		local numOflines = (currentTextBounds.Y/CHAT_BUBBLE_FONT_SIZE_INT)
 
 		-- prep chat bubble for tween
 		chatBubbleRender.Size = UDim2.new(0,0,0,0)

--- a/CoreScriptsRoot/Modules/Server/ClientChat/ChatMain.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/ChatMain.lua
@@ -124,8 +124,6 @@ local moduleMessageLogDisplay = require(modulesFolder:WaitForChild("MessageLogDi
 local moduleChatChannel = require(modulesFolder:WaitForChild("ChatChannel"))
 local moduleCommandProcessor = require(modulesFolder:WaitForChild("CommandProcessor"))
 
-moduleMessageLabelCreator:RegisterGuiRoot(GuiParent)
-
 local ChatWindow = moduleChatWindow.new()
 local ChannelsBar = moduleChannelsBar.new()
 local MessageLogDisplay = moduleMessageLogDisplay.new()

--- a/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/MessageCreatorModules/Util.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/MessageCreatorModules/Util.lua
@@ -36,6 +36,8 @@ local KEY_FADE_IN = "FadeInFunction"
 local KEY_FADE_OUT = "FadeOutFunction"
 local KEY_UPDATE_ANIMATION = "UpdateAnimFunction"
 
+local TextService = game:GetService("TextService")
+
 local Players = game:GetService("Players")
 local LocalPlayer = Players.LocalPlayer
 while not LocalPlayer do
@@ -50,49 +52,15 @@ local module = {}
 local methods = {}
 methods.__index = methods
 
-local testLabel = Instance.new("TextLabel")
-testLabel.Selectable = false
-testLabel.TextWrapped = true
-testLabel.Position = UDim2.new(1, 0, 1, 0)
-
-function WaitUntilParentedCorrectly()
-	while not testLabel:IsDescendantOf(LocalPlayer) do
-		testLabel.AncestryChanged:wait()
-	end
-end
-
-local TextSizeCache = {}
 function methods:GetStringTextBounds(text, font, textSize, sizeBounds)
-	WaitUntilParentedCorrectly()
-	sizeBounds = sizeBounds or false
-	if not TextSizeCache[text] then
-		TextSizeCache[text] = {}
-	end
-	if not TextSizeCache[text][font] then
-		TextSizeCache[text][font] = {}
-	end
-	if not TextSizeCache[text][font][sizeBounds] then
-		TextSizeCache[text][font][sizeBounds] = {}
-	end
-	if not TextSizeCache[text][font][sizeBounds][textSize] then
-		testLabel.Text = text
-		testLabel.Font = font
-		testLabel.TextSize = textSize
-		if sizeBounds then
-			testLabel.TextWrapped = true;
-			testLabel.Size = sizeBounds
-		else
-			testLabel.TextWrapped = false;
-		end
-		TextSizeCache[text][font][sizeBounds][textSize] = testLabel.TextBounds
-	end
-	return TextSizeCache[text][font][sizeBounds][textSize]
+	sizeBounds = sizeBounds or Vector2.new(10000, 10000)
+	return TextService:GetTextSize(text, textSize, font, sizeBounds)
 end
 --// Above was taken directly from Util.GetStringTextBounds() in the old chat corescripts.
 
 function methods:GetMessageHeight(BaseMessage, BaseFrame, xSize)
 	xSize = xSize or BaseFrame.AbsoluteSize.X
-	local textBoundsSize = self:GetStringTextBounds(BaseMessage.Text, BaseMessage.Font, BaseMessage.TextSize, UDim2.new(0, xSize, 0, 1000))
+	local textBoundsSize = self:GetStringTextBounds(BaseMessage.Text, BaseMessage.Font, BaseMessage.TextSize, Vector2.new(xSize, 1000))
 	return textBoundsSize.Y
 end
 
@@ -239,10 +207,6 @@ end
 
 function methods:RegisterObjectPool(objectPool)
 	self.ObjectPool = objectPool
-end
-
-function methods:RegisterGuiRoot(root)
-	testLabel.Parent = root
 end
 
 -- CreateFadeFunctions usage:

--- a/CoreScriptsRoot/Modules/Server/ClientChat/MessageLabelCreator.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/MessageLabelCreator.lua
@@ -109,10 +109,6 @@ function module.new()
 	return obj
 end
 
-function module:RegisterGuiRoot(root)
-	messageCreatorUtil:RegisterGuiRoot(root)
-end
-
 function module:GetStringTextBounds(text, font, textSize, sizeBounds)
 	return messageCreatorUtil:GetStringTextBounds(text, font, textSize, sizeBounds)
 end


### PR DESCRIPTION
This lua implementation is no longer necessary because TextService:GetTextSize() has been changed to userscript level. This also had a memory leak: http://devforum.roblox.com/t/bubblechat-playerscript-textsizecache-memory-leak/33608 