### PR TITLE
Update settings menu for Xbox emulation.

### DIFF
--- a/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
@@ -807,7 +807,7 @@ local function Initialize()
   end
 
   local function createOverscanOption()
-  	local showOverscanScreen = function()
+      local showOverscanScreen = function()
       if RunService:IsStudio() then
         return
       end

--- a/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
@@ -807,10 +807,10 @@ local function Initialize()
   end
 
   local function createOverscanOption()
-    local showOverscanScreen = function()
-			if RunService:IsStudio() then
-				return
-			end
+  	local showOverscanScreen = function()
+      if RunService:IsStudio() then
+        return
+      end
 
       if not overscanScreen then
         local overscanModule = RobloxGui.Modules:FindFirstChild('OverscanScreen')
@@ -853,12 +853,12 @@ local function Initialize()
     adjustText.Font = Enum.Font.SourceSans
     adjustButton.Position = UDim2.new(1,-400,0,12)
 
-		if RunService:IsStudio() then
-			adjustButton.Selectable = value
-			adjustButton.Active = value
-			adjustButton.Enabled.Value = value
-			adjustText.TextColor3 = Color3.fromRGB(100, 100, 100)
-		end
+    if RunService:IsStudio() then
+      adjustButton.Selectable = value
+      adjustButton.Active = value
+      adjustButton.Enabled.Value = value
+      adjustText.TextColor3 = Color3.fromRGB(100, 100, 100)
+    end
 
     local row = utility:AddNewRowObject(this, "Safe Zone", adjustButton)
     setButtonRowRef(row)

--- a/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/GameSettings.lua
@@ -10,6 +10,7 @@ local CoreGui = game:GetService("CoreGui")
 local RobloxGui = CoreGui:WaitForChild("RobloxGui")
 local GuiService = game:GetService("GuiService")
 local UserInputService = game:GetService("UserInputService")
+local RunService = game:GetService("RunService")
 local PlatformService = nil
 pcall(function() PlatformService = game:GetService("PlatformService") end)
 local ContextActionService = game:GetService("ContextActionService")
@@ -293,7 +294,7 @@ local function Initialize()
     ------------------------------------------------------
     ------------------
     ------------------ Shift Lock Switch -----------------
-    if UserInputService.MouseEnabled then
+    if UserInputService.MouseEnabled and not isTenFootInterface then
       this.ShiftLockFrame,
       this.ShiftLockLabel,
       this.ShiftLockMode,
@@ -807,6 +808,9 @@ local function Initialize()
 
   local function createOverscanOption()
     local showOverscanScreen = function()
+			if RunService:IsStudio() then
+				return
+			end
 
       if not overscanScreen then
         local overscanModule = RobloxGui.Modules:FindFirstChild('OverscanScreen')
@@ -848,6 +852,13 @@ local function Initialize()
     local adjustButton, adjustText, setButtonRowRef = utility:MakeStyledButton("AdjustButton", "Adjust", UDim2.new(0,300,1,-20), showOverscanScreen, this)
     adjustText.Font = Enum.Font.SourceSans
     adjustButton.Position = UDim2.new(1,-400,0,12)
+
+		if RunService:IsStudio() then
+			adjustButton.Selectable = value
+			adjustButton.Active = value
+			adjustButton.Enabled.Value = value
+			adjustText.TextColor3 = Color3.fromRGB(100, 100, 100)
+		end
 
     local row = utility:AddNewRowObject(this, "Safe Zone", adjustButton)
     setButtonRowRef(row)
@@ -893,7 +904,7 @@ local function Initialize()
   createCameraModeOptions(not isTenFootInterface and
     (UserInputService.TouchEnabled or UserInputService.MouseEnabled or UserInputService.KeyboardEnabled))
 
-  if UserInputService.MouseEnabled then
+  if UserInputService.MouseEnabled and not isTenFootInterface then
     createMouseOptions()
   end
 

--- a/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
@@ -241,8 +241,8 @@ local function CreateSettingsHub()
 				setResetEnabled(true)
 			end
 		end)
-	end	
-	
+	end
+
 	local function createGui()
 		local PageViewSizeReducer = 0
 		if isSmallTouchScreen then
@@ -384,12 +384,14 @@ local function CreateSettingsHub()
 				removeBottomBarBindings()
 				this:SwitchToPage(this.LeaveGamePage, nil, 1, true)
 			end
-		 
+
 			-- Xbox Only
 			local inviteToGameFunc = function()
-				local platformService = game:GetService('PlatformService')
-				if platformService then
-					platformService:PopupGameInviteUI()
+				if not RunService:IsStudio() then
+					local platformService = game:GetService('PlatformService')
+					if platformService then
+						platformService:PopupGameInviteUI()
+					end
 				end
 			end
 
@@ -409,6 +411,19 @@ local function CreateSettingsHub()
 						"", UDim2.new(0.5,isTenFootInterface and -160 or -130,0.5,-25),
 						inviteToGameFunc, {Enum.KeyCode.ButtonX}
 					)
+					if RunService:IsStudio() then
+						this.InviteToGameButton.Selectable = value
+						this.InviteToGameButton.Active = value
+						this.InviteToGameButton.Enabled.Value = value
+						local inviteHint = this.InviteToGameButton:FindFirstChild("InviteToGameHint")
+						if inviteHint then
+							inviteHint.ImageColor3 = Color3.fromRGB(100, 100, 100)
+						end
+						local inviteButtonText = this.InviteToGameText
+						if inviteButtonText then
+							inviteButtonText.TextColor3 = Color3.fromRGB(100, 100, 100)
+						end
+					end
 				end
 
 				if IsPlayMyPlaceEnabled() then
@@ -438,7 +453,7 @@ local function CreateSettingsHub()
 					this:SwitchToPage(this.ResetCharacterPage, nil, 1, true)
 				end
 			end
-			
+
 			addBottomBarButton("ResetCharacter", "		Reset Character", "rbxasset://textures/ui/Settings/Help/YButtonLight" .. buttonImageAppend .. ".png",
 				"rbxasset://textures/ui/Settings/Help/ResetIcon.png", UDim2.new(0.5,isTenFootInterface and -550 or -400,0.5,-25),
 				resetCharFunc, {Enum.KeyCode.R, Enum.KeyCode.ButtonY}
@@ -557,15 +572,15 @@ local function CreateSettingsHub()
 		onScreenSizeChanged()
 	end
 
-	local function toggleQuickProfilerFromHotkey(actionName, inputState, inputObject) 
+	local function toggleQuickProfilerFromHotkey(actionName, inputState, inputObject)
 		-- Make sure it's Ctrl-F7.
 		-- NOTE: This will only work if FFlagDontSwallowInputForStudioShortcuts is True.
 		-- Otherwise, we never get the "Begin" input state when Ctrl key is down.
-		if (not (UserInputService:IsKeyDown(Enum.KeyCode.LeftControl) or 
+		if (not (UserInputService:IsKeyDown(Enum.KeyCode.LeftControl) or
 				UserInputService:IsKeyDown(Enum.KeyCode.RightControl))) then
 			return
 		end
-		
+
 		if actionName ==QUICK_PROFILER_ACTION_NAME then
 			if inputState and inputState == Enum.UserInputState.Begin then
 				GameSettings.PerformanceStatsVisible = not GameSettings.PerformanceStatsVisible
@@ -583,7 +598,7 @@ local function CreateSettingsHub()
 	end
 
 	local lastInputUsedToSelectGui = isTenFootInterface
-	
+
 	-- Map indicating if a KeyCode or UserInputType should toggle the lastInputUsedToSelectGui variable.
 	local inputUsedToSelectGui = {
 		[Enum.UserInputType.Gamepad1] = true,
@@ -599,7 +614,7 @@ local function CreateSettingsHub()
 		[Enum.UserInputType.MouseButton1] = false,
 		[Enum.UserInputType.MouseButton2] = false
 	}
-	
+
 	UserInputService.InputBegan:connect(function(input)
 		if input.UserInputType and inputUsedToSelectGui[input.UserInputType] ~= nil then
 			lastInputUsedToSelectGui = inputUsedToSelectGui[input.UserInputType]
@@ -1191,17 +1206,17 @@ local function CreateSettingsHub()
 	end)
 
 	-- Dev Console Connections
-	ContextActionService:BindCoreAction(DEV_CONSOLE_ACTION_NAME, 
-		toggleDevConsole, 
+	ContextActionService:BindCoreAction(DEV_CONSOLE_ACTION_NAME,
+		toggleDevConsole,
 		false,
 		Enum.KeyCode.F9
 	)
 
 	-- Quick Profiler connections
-	-- Note: it's actually Ctrl-F7.	We don't have a nice way of 
+	-- Note: it's actually Ctrl-F7.	We don't have a nice way of
 	-- making that explicit here, so we check it inside toggleQuickProfilerFromHotkey.
-	ContextActionService:BindCoreAction(QUICK_PROFILER_ACTION_NAME, 
-		toggleQuickProfilerFromHotkey, 
+	ContextActionService:BindCoreAction(QUICK_PROFILER_ACTION_NAME,
+		toggleQuickProfilerFromHotkey,
 		false,
 		Enum.KeyCode.F7
 	)


### PR DESCRIPTION
CLI-15358

When emulating xBox in studio:
Hide "Shift Lock Switch"
Hide "Mouse Sensitivity"
Disable the "Safe Zone" option (make the label and button grayed out)
Disable the "Send Game Invites" button (make the label gray and tint the icon to grayscale using ImageColor3)