### PR TITLE
Dont update DialogPanel when VR is disabled

### DIFF
--- a/CoreScriptsRoot/Modules/VR/Dialog.lua
+++ b/CoreScriptsRoot/Modules/VR/Dialog.lua
@@ -5,6 +5,7 @@
 local CoreGui = game:GetService("CoreGui")
 local RobloxGui = CoreGui:WaitForChild("RobloxGui")
 local InputService = game:GetService("UserInputService")
+local VRService = game:GetService("VRService")
 local Utility = require(RobloxGui.Modules.Settings.Utility)
 local Panel3D = require(RobloxGui.Modules.VR.Panel3D)
 
@@ -79,6 +80,10 @@ end
 
 
 game:GetService("RunService"):BindToRenderStep("DialogPanel", Enum.RenderPriority.First.Value, function()
+	if not VRService.VREnabled then
+		return
+	end
+	
 	if DialogPanel.transparency == 1 or resetBaseAngle then
 		updatePanelPosition()
 	end

--- a/CoreScriptsRoot/Modules/VR/Dialog.lua
+++ b/CoreScriptsRoot/Modules/VR/Dialog.lua
@@ -189,6 +189,10 @@ function Dialog:Close()
 			break
 		end
 	end
+	if renderFuncBound and #DialogQueue == 0 then
+		renderFuncBound = false
+		RunService:UnbindFromRenderStep("DialogPanel")
+	end	
 	updatePanel()
 end
 

--- a/CoreScriptsRoot/Modules/VR/Dialog.lua
+++ b/CoreScriptsRoot/Modules/VR/Dialog.lua
@@ -96,7 +96,7 @@ function dialogPanelRenderUpdate()
 			guiElement.BackgroundTransparency = transparency
 		end
 	end
-end)
+end
 
 local DialogQueue = {}
 

--- a/CoreScriptsRoot/Modules/VR/Dialog.lua
+++ b/CoreScriptsRoot/Modules/VR/Dialog.lua
@@ -5,7 +5,7 @@
 local CoreGui = game:GetService("CoreGui")
 local RobloxGui = CoreGui:WaitForChild("RobloxGui")
 local InputService = game:GetService("UserInputService")
-local VRService = game:GetService("VRService")
+local RunService = game:GetService("RunService")
 local Utility = require(RobloxGui.Modules.Settings.Utility)
 local Panel3D = require(RobloxGui.Modules.VR.Panel3D)
 
@@ -78,12 +78,8 @@ local function updatePanelPosition()
 	positionDialogPanel(newPanelAngle)
 end
 
-
-game:GetService("RunService"):BindToRenderStep("DialogPanel", Enum.RenderPriority.First.Value, function()
-	if not VRService.VREnabled then
-		return
-	end
-	
+-- RenderStep update function for the DialogPanel
+function dialogPanelRenderUpdate()	
 	if DialogPanel.transparency == 1 or resetBaseAngle then
 		updatePanelPosition()
 	end
@@ -172,7 +168,12 @@ function Dialog:SetContent(guiElement)
 	self.content = guiElement
 end
 
+local renderFuncBound = false
 function Dialog:Show(shouldTakeover)
+	if not renderFuncBound then
+		renderFuncBound = true
+		RunService:BindToRenderStep("DialogPanel", Enum.RenderPriority.First.Value, dialogPanelRenderUpdate)
+	end
 	if shouldTakeover then
 		table.insert(DialogQueue, 1, self)
 	else


### PR DESCRIPTION
We should avoid doing this update every RenderStep when VR is disabled.
I changed the bound render step function to exit early if VR is not
enabled. We could instead just not bind the function at all, Kyle can
take a look at doing that instead.