### PR TITLE
Make ControlScript render step function faster

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl.rbxmx
@@ -68,7 +68,7 @@ local function characterAdded(character)
 	LocalCharacter = character
 	CachedHumanoid = LocalCharacter:FindFirstChildOfClass("Humanoid")
 	characterAncestryChangedConn = character.AncestryChanged:connect(function()
-		if not character:IsDescendantOf(workspace) then
+		if character.Parent == nil then
 			LocalCharacter = nil
 		else
 			LocalCharacter = character
@@ -92,6 +92,7 @@ function MasterControl:Init()
 
 	local getHumanoid = self.GetHumanoid
 	local moveFunc = LocalPlayer.Move
+	local getUserCFrame = VRService.GetUserCFrame
 	local renderStepFunc = function()
 		local humanoid = getHumanoid()
 		if not humanoid then return end
@@ -105,7 +106,7 @@ function MasterControl:Init()
 		
 		local adjustedMoveValue = moveValue
 		if VREnabled and workspace.CurrentCamera.HeadLocked then
-			local vrFrame = VRService:GetUserCFrame()
+			local vrFrame = getUserCFrame(VRService)
 			local lookVector = Vector3.new(vrFrame.lookVector.X, 0, vrFrame.lookVector.Z).unit
 			local rotation = CFrame.new(ZERO_VECTOR3, lookVector)
 			adjustedMoveValue = rotation:vectorToWorldSpace(adjustedMoveValue)

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl.rbxmx
@@ -12,95 +12,115 @@
 	// Description: All character control scripts go thru this script, this script makes sure all actions are performed
 --]]
 
+-- [[ Constants ]]--
+local ZERO_VECTOR3 = Vector3.new(0, 0, 0)
+local STATE_JUMPING = Enum.HumanoidStateType.Jumping
+local STATE_FREEFALL = Enum.HumanoidStateType.Freefall
+local STATE_LANDED = Enum.HumanoidStateType.Landed
+
 --[[ Local Variables ]]--
 local MasterControl = {}
 
 local Players = game:GetService('Players')
 local RunService = game:GetService('RunService')
-local UserInputService = game:GetService('UserInputService')
-
-local HasVRAPI = pcall(function() return UserInputService.VREnabled and UserInputService.GetUserCFrame end)
+local VRService = game:GetService('VRService')
+local VREnabled = VRService.VREnabled
 
 while not Players.LocalPlayer do
-	wait()
+	Players.PlayerAdded:wait()
 end
 local LocalPlayer = Players.LocalPlayer
+local LocalCharacter = LocalPlayer.Character
 local CachedHumanoid = nil
-local RenderSteppedCon = nil
-local SeatedCn = nil
-local moveFunc = LocalPlayer.Move
 
 local isJumping = false
-local isSeated = false
-local myVehicleSeat = nil
-local moveValue = Vector3.new(0,0,0)
-
+local moveValue = Vector3.new(0, 0, 0)
 
 --[[ Local Functions ]]--
 function MasterControl:GetHumanoid()
-	local character = LocalPlayer and LocalPlayer.Character
-	if character then
-		if CachedHumanoid and CachedHumanoid.Parent == character then
+	if LocalCharacter then
+		if CachedHumanoid then
 			return CachedHumanoid
 		else
-			CachedHumanoid = nil
-			for _,child in pairs(character:GetChildren()) do
-				if child:IsA('Humanoid') then
-					CachedHumanoid = child
-					return CachedHumanoid
-				end
-			end
+			CachedHumanoid = LocalCharacter:FindFirstChildOfClass("Humanoid")
+			return CachedHumanoid
 		end
 	end
 end
+
+VRService.Changed:connect(function(prop)
+	if prop == "VREnabled" then
+		VREnabled = VRService.VREnabled
+	end
+end)
+
+local characterAncestryChangedConn = nil
+local characterChildRemovedConn = nil
+local function characterAdded(character)
+	if characterAncestryChangedConn then
+		characterAncestryChangedConn:disconnect()
+	end
+
+	if characterChildRemovedConn then
+		characterChildRemovedConn:disconnect()
+	end	
+	
+	LocalCharacter = character
+	CachedHumanoid = LocalCharacter:FindFirstChildOfClass("Humanoid")
+	characterAncestryChangedConn = character.AncestryChanged:connect(function()
+		if not character:IsDescendantOf(workspace) then
+			LocalCharacter = nil
+		else
+			LocalCharacter = character
+		end
+	end)
+	
+	characterChildRemovedConn = character.ChildRemoved:connect(function(child)
+		if child == CachedHumanoid then
+			CachedHumanoid = nil
+		end
+	end)
+end
+
+if LocalCharacter then
+	characterAdded(LocalCharacter)
+end
+LocalPlayer.CharacterAdded:connect(characterAdded)
 
 --[[ Public API ]]--
 function MasterControl:Init()
-	
+
+	local getHumanoid = self.GetHumanoid
+	local moveFunc = LocalPlayer.Move
 	local renderStepFunc = function()
-		if LocalPlayer and LocalPlayer.Character then
-			local humanoid = self:GetHumanoid()
-			if not humanoid then return end
+		local humanoid = getHumanoid()
+		if not humanoid then return end
 			
-			if humanoid and not humanoid.PlatformStand and isJumping then
-				local state = humanoid:GetState()
-				if state ~= Enum.HumanoidStateType.Jumping and state ~= Enum.HumanoidStateType.Freefall and state ~= Enum.HumanoidStateType.Landed then
-					humanoid.Jump = isJumping
-				end
+		if isJumping and not humanoid.PlatformStand then
+			local state = humanoid:GetState()
+			if state ~= STATE_JUMPING and state ~= STATE_FREEFALL and state ~= STATE_LANDED then
+				humanoid.Jump = isJumping
 			end
-			
-			local adjustedMoveValue = moveValue
-			if HasVRAPI and UserInputService.VREnabled and workspace.CurrentCamera.HeadLocked then
-				local vrFrame = UserInputService.UserHeadCFrame
-				local lookVector = Vector3.new(vrFrame.lookVector.X, 0, vrFrame.lookVector.Z).unit
-				local rotation = CFrame.new(Vector3.new(0, 0, 0), lookVector)
-				adjustedMoveValue = rotation:vectorToWorldSpace(adjustedMoveValue)
-			end
-			
-			moveFunc(LocalPlayer, adjustedMoveValue, true)	
-			
-			
 		end
+		
+		local adjustedMoveValue = moveValue
+		if VREnabled and workspace.CurrentCamera.HeadLocked then
+			local vrFrame = VRService:GetUserCFrame()
+			local lookVector = Vector3.new(vrFrame.lookVector.X, 0, vrFrame.lookVector.Z).unit
+			local rotation = CFrame.new(ZERO_VECTOR3, lookVector)
+			adjustedMoveValue = rotation:vectorToWorldSpace(adjustedMoveValue)
+		end
+
+		moveFunc(LocalPlayer, adjustedMoveValue, true)
 	end
 	
-	local success = pcall(function() RunService:BindToRenderStep("MasterControlStep", Enum.RenderPriority.Input.Value, renderStepFunc) end)
-	
-	if not success then
-		if RenderSteppedCon then return end
-		RenderSteppedCon = RunService.RenderStepped:connect(renderStepFunc)
-	end
+	RunService:BindToRenderStep("MasterControlStep", Enum.RenderPriority.Input.Value, renderStepFunc)
 end
 
 function MasterControl:Disable()
-	local success = pcall(function() RunService:UnbindFromRenderStep("MasterControlStep") end)
-	if not success then
-		if RenderSteppedCon then
-			RenderSteppedCon:disconnect()
-			RenderSteppedCon = nil
-		end
-	end
+	RunService:UnbindFromRenderStep("MasterControlStep")
 	
-	moveValue = Vector3.new(0,0,0)
+	moveValue = ZERO_VECTOR3
 	isJumping = false
 end
 


### PR DESCRIPTION
- Better manage the CachedHumanoid so we don't have to make sure it's in
the character when GetHumanoid is called
- Re-order if statement so humanoid.PlatformStand is not checked unless
isJumping is true.
- Cache VREnabled value so it doesn't need to be read every frame.
- Also removed some unused variables and unused code.