### PR TITLE
Check that currentSeatPart is non-nil in onSeated function

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/ClickToMove.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/ClickToMove.rbxmx
@@ -1490,7 +1490,7 @@ local function CreateClickToMoveModule()
 				if BindableEvent_EnableTouchJump then
 					BindableEvent_EnableTouchJump:Fire(true)
 				end
-				if currentSeatPart.ClassName == "VehicleSeat" then
+				if currentSeatPart and currentSeatPart.ClassName == "VehicleSeat" then
 					CurrentSeatPart = currentSeatPart
 					if AutoJumperInstance then
 						AutoJumperInstance:Stop()


### PR DESCRIPTION
See this devforum thread for the report:

http://devforum.roblox.com/t/when-creating-a-seatweld-manually-to-a-non-seat-clicktomove-controls-throw-an-error/34036

Also going to ask the developer what code is being used to reproduce
this and see if the onSeated event needs to be updated.