### PR TITLE
Fix chat click to whisper sometimes whispering a random player.

### DIFF
--- a/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/MessageCreatorModules/Util.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/MessageCreatorModules/Util.lua
@@ -117,8 +117,17 @@ function methods:AddNameButtonToBaseMessage(BaseMessage, nameColor, formatName, 
 	NameButton.Visible = true
 	NameButton.Parent = BaseMessage
 
-	NameButton.MouseButton1Click:connect(function()
+	local clickedConn = NameButton.MouseButton1Click:connect(function()
 		self:NameButtonClicked(NameButton, playerName)
+	end)
+
+	local changedConn = nil
+	changedConn = NameButton.Changed:connect(function(prop)
+		if prop == "Parent" then
+			print("Disconnecting!")
+			clickedConn:Disconnect()
+			changedConn:Disconnect()
+		end
 	end)
 
 	return NameButton
@@ -142,8 +151,16 @@ function methods:AddChannelButtonToBaseMessage(BaseMessage, channelColor, format
 	ChannelButton.Visible = true
 	ChannelButton.Parent = BaseMessage
 
-	ChannelButton.MouseButton1Click:connect(function()
+	local clickedConn = ChannelButton.MouseButton1Click:connect(function()
 		self:ChannelButtonClicked(ChannelButton, channelName)
+	end)
+
+	local changedConn = nil
+ 	changedConn = ChannelButton.Changed:connect(function(prop)
+		if prop == "Parent" then
+			clickedConn:Disconnect()
+			changedConn:Disconnect()
+		end
 	end)
 
 	return ChannelButton

--- a/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/MessageCreatorModules/Util.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/MessageCreatorModules/Util.lua
@@ -124,7 +124,6 @@ function methods:AddNameButtonToBaseMessage(BaseMessage, nameColor, formatName, 
 	local changedConn = nil
 	changedConn = NameButton.Changed:connect(function(prop)
 		if prop == "Parent" then
-			print("Disconnecting!")
 			clickedConn:Disconnect()
 			changedConn:Disconnect()
 		end


### PR DESCRIPTION
This is caused by not disconnecting the connections on NameButton before returning it to the object pool.