### PR TITLE
Legacy partial copy versions of the chat are broken by the new update

### DIFF
--- a/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/MessageCreatorModules/Util.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/MessageCreatorModules/Util.lua
@@ -304,6 +304,10 @@ function methods:NewBindableEvent(name)
 	return bindable
 end
 
+function methods:RegisterGuiRoot()
+	-- This is left here for compatibility with legacy chat versions.
+end
+
 function module.new()
 	local obj = setmetatable({}, methods)
 

--- a/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/MessageCreatorModules/Util.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/MessageCreatorModules/Util.lua
@@ -304,9 +304,11 @@ function methods:NewBindableEvent(name)
 	return bindable
 end
 
+--- DEPRECATED METHODS:
 function methods:RegisterGuiRoot()
-	-- This is left here for compatibility with legacy chat versions.
+	-- This is left here for compatibility with ChatScript versions lower than 0.5
 end
+--- End of Deprecated methods.
 
 function module.new()
 	local obj = setmetatable({}, methods)


### PR DESCRIPTION
Partial copies versions of the chat that copy ChatScript but do not copy the MessageCreatorModules are broken by the new update to the chat system. RegisterGuiRoot is removed from MessageCreatorUtil and old versions of the chat still expect this to exist. This bug causes chat to be broken in meep city.

CLI-15602