### PR TITLE
Fix thumbpad breaking when you reset

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript.rbxmx
@@ -1,11 +1,12 @@
 <roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
 	<External>null</External>
 	<External>nil</External>
-	<Item class="LocalScript" referent="RBX6ECBB953392B4C62B547B37A9AEBD054">
+	<Item class="LocalScript" referent="RBX07897057CB3E4B75952AC6E3D364A6C2">
 		<Properties>
 			<bool name="Disabled">false</bool>
 			<Content name="LinkedSource"><null></null></Content>
 			<string name="Name">ControlScript</string>
+			<string name="ScriptGuid">{EFAAF843-127B-494C-8C86-A346B5963EA7}</string>
 			<ProtectedString name="Source"><![CDATA[--[[
 	// FileName: ControlScript.lua
 	// Version 1.1
@@ -320,6 +321,7 @@ local function createTouchGuiContainer()
 	-- Container for all touch device guis
 	TouchGui = Instance.new('ScreenGui')
 	TouchGui.Name = "TouchGui"
+	TouchGui.ResetOnSpawn = false
 	TouchGui.Parent = PlayerGui
 	
 	TouchControlFrame = Instance.new('Frame')
@@ -357,28 +359,6 @@ GameSettings.Changed:connect(function(property)
 end)
 
 --[[ Touch Events ]]--
--- On touch devices we need to recreate the guis on character load.
-local lastControlState = nil
-LocalPlayer.CharacterAdded:connect(function(character)
-	if ControlState.Current then -- only do this if it wasn't done through CharacterRemoving
-		lastControlState = ControlState.Current
-		ControlState:SwitchTo(nil)
-	end
-	
-	if UserInputService.TouchEnabled then
-		createTouchGuiContainer()
-	end
-	
-	if ControlState.Current == nil then
-		ControlState:SwitchTo(lastControlState)
-	end
-end)
-
-LocalPlayer.CharacterRemoving:connect(function()
-	lastControlState = ControlState.Current
-	ControlState:SwitchTo(nil)
-end)
-	
 UserInputService.Changed:connect(function(property)
 	if property == 'ModalEnabled' then
 		IsModalEnabled = UserInputService.ModalEnabled


### PR DESCRIPTION
This was caused by attempting to tween the thumbpad when it was not a child of the datamodel (when it was being reset). This fix stops the mobile GUI being reset on spawn using the new ScreenGui.ResetOnSpawn property. 