### PR TITLE
Add hook for ScreenshotReady event to NotificationScript2

### DIFF
--- a/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
@@ -727,7 +727,7 @@ end
 if disableScreenshotPopup then
 	game.ScreenshotReady:Connect(function(path)
 		sendNotificationInfo {
-			Title = "Screenshot Ready",
+			Title = "Screenshot Taken",
 			Text = "Check out your screenshots folder to see it.",
 			Duration = 3.0,
 			Button1Text = "Open Folder",

--- a/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
@@ -40,8 +40,8 @@ local newNotificationPath = getNewNotificationPathSuccess and newNotificationPat
 local getTenFootBadgeNotifications, tenFootBadgeNotificationsValue = pcall(function() return settings():GetFFlag("TenFootBadgeNotifications") end)
 local tenFootBadgeNotifications = getTenFootBadgeNotifications and tenFootBadgeNotificationsValue
 
-local disableScreenshotPopup, disableScreenshotPopupValue = pcall(function() return settings():GetFFlag("DisableScreenshotPopup") end)
-local disableScreenshotPopup = disableScreenshotPopup and disableScreenshotPopupValue
+local getDisableScreenshotPopup, disableScreenshotPopupValue = pcall(function() return settings():GetFFlag("DisableScreenshotPopup") end)
+local disableScreenshotPopup = getDisableScreenshotPopup and disableScreenshotPopupValue
 
 --[[ Script Variables ]]--
 local LocalPlayer = nil

--- a/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
@@ -40,6 +40,9 @@ local newNotificationPath = getNewNotificationPathSuccess and newNotificationPat
 local getTenFootBadgeNotifications, tenFootBadgeNotificationsValue = pcall(function() return settings():GetFFlag("TenFootBadgeNotifications") end)
 local tenFootBadgeNotifications = getTenFootBadgeNotifications and tenFootBadgeNotificationsValue
 
+local disableScreenshotPopup, disableScreenshotPopupValue = pcall(function() return settings():GetFFlag("DisableScreenshotPopup") end)
+local disableScreenshotPopup = disableScreenshotPopup and disableScreenshotPopupValue
+
 --[[ Script Variables ]]--
 local LocalPlayer = nil
 while not Players.LocalPlayer do
@@ -719,6 +722,22 @@ if not isTenFootInterface then
 	end)
 end
 
+end
+
+if disableScreenshotPopup then
+	game.ScreenshotReady:Connect(function(path)
+		sendNotificationInfo {
+			Title = "Screenshot Ready",
+			Text = "Check out your screenshots folder to see it.",
+			Duration = 3.0,
+			Button1Text = "Open Folder",
+			Callback = function(text)
+				if text == "Open Folder" then
+					game:OpenScreenshotsFolder()
+				end
+			end
+		}
+	end)
 end
 
 GuiService.SendCoreUiNotification = function(title, text)


### PR DESCRIPTION
This flag removes both the old internet explorer window and the old ShowMessage() based notifications for screenshots, replacing them with a corescripts notification.