### PR TITLE
Trim trailing whitespace on messages.

### DIFF
--- a/CoreScriptsRoot/Modules/Server/ClientChat/ChatMain.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/ChatMain.lua
@@ -510,6 +510,19 @@ moduleApiTable.CoreGuiEnabled:connect(function(enabled)
 	end
 end)
 
+function trimTrailingSpaces(str)
+	local lastSpace = #str
+	while lastSpace > 0 do
+		--- The pattern ^%s matches whitespace at the start of the string. (Starting from lastSpace)
+		if str:find("^%s", lastSpace) then
+			lastSpace = lastSpace - 1
+		else
+			break
+		end
+	end
+	return str:sub(1, lastSpace)
+end
+
 moduleApiTable.ChatMakeSystemMessageEvent:connect(function(valueTable)
 	if (valueTable["Text"] and type(valueTable["Text"]) == "string") then
 		while (not DidFirstChannelsLoads) do wait() end
@@ -525,7 +538,7 @@ moduleApiTable.ChatMakeSystemMessageEvent:connect(function(valueTable)
 				OriginalChannel = channel,
 				IsFiltered = true,
 				MessageLength = string.len(valueTable.Text),
-				Message = valueTable.Text,
+				Message = trimTrailingSpaces(valueTable.Text),
 				MessageType = ChatConstants.MessageTypeSetCore,
 				Time = os.time(),
 				ExtraData = valueTable,
@@ -593,7 +606,7 @@ function SendMessageToSelfInTargetChannel(message, channelName, extraData)
 			OriginalChannel = channelName,
 			IsFiltered = true,
 			MessageLength = string.len(message),
-			Message = message,
+			Message = trimTrailingSpaces(message),
 			MessageType = ChatConstants.MessageTypeSystem,
 			Time = os.time(),
 			ExtraData = extraData,
@@ -805,7 +818,7 @@ function HandleChannelJoined(channel, welcomeMessage, messageLog, channelNameCol
 				OriginalChannel = channel,
 				IsFiltered = true,
 				MessageLength = string.len(welcomeMessage),
-				Message = welcomeMessage,
+				Message = trimTrailingSpaces(welcomeMessage),
 				MessageType = ChatConstants.MessageTypeWelcome,
 				Time = os.time(),
 				ExtraData = nil,
@@ -958,7 +971,7 @@ function SendSystemMessageToSelf(message)
 			OriginalChannel = currentChannel.Name,
 			IsFiltered = true,
 			MessageLength = string.len(message),
-			Message = message,
+			Message = trimTrailingSpaces(message),
 			MessageType = ChatConstants.MessageTypeSystem,
 			Time = os.time(),
 			ExtraData = nil,


### PR DESCRIPTION
Currently trailing whitespace is included in the text bounds of messages, and lines are not wrapped in the middle of lines. This can cause issues calculating the size of messages. Trim trailing whitespace on messages to avoid this problem. 