### PR TITLE
Remove Fast Flags

### DIFF
--- a/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
@@ -28,12 +28,6 @@ local Settings = UserSettings()
 local GameSettings = Settings.GameSettings
 
 --[[ Fast Flags ]]--
-local getNotificationDisableSuccess, notificationsDisableActiveValue = pcall(function() return settings():GetFFlag("SetCoreDisableNotifications") end)
-local allowDisableNotifications = getNotificationDisableSuccess and notificationsDisableActiveValue
-
-local getSendNotificationSuccess, sendNotificationActiveValue = pcall(function() return settings():GetFFlag("SetCoreSendNotifications") end)
-local allowSendNotifications = getSendNotificationSuccess and sendNotificationActiveValue
-
 local getNewNotificationPathSuccess, newNotificationPathValue = pcall(function() return settings():GetFFlag("UseNewNotificationPathLua") end)
 local newNotificationPath = getNewNotificationPathSuccess and newNotificationPathValue
 
@@ -482,10 +476,10 @@ end)
 
 local checkFriendRequestIsThrottled; do
 	local friendRequestThrottlingMap = {}
-	
+
 	checkFriendRequestIsThrottled = function(fromPlayer)
 		local throttleFinishedTime = friendRequestThrottlingMap[fromPlayer]
-		
+
 		if throttleFinishedTime then
 			if tick() < throttleFinishedTime then
 				return true
@@ -503,7 +497,7 @@ local function sendFriendNotification(fromPlayer)
 		if checkFriendRequestIsThrottled(fromPlayer) then
 			return
 		end
-	
+
 		local acceptText = "Accept"
 		local declineText = "Decline"
 		sendNotificationInfo {
@@ -831,22 +825,13 @@ local function createDeveloperNotification(notificationTable)
 	end
 end
 
-if allowDisableNotifications then
-	StarterGui:RegisterSetCore("PointsNotificationsActive", function(value) if type(value) == "boolean" then pointsNotificationsActive = value end end)
-	StarterGui:RegisterSetCore("BadgesNotificationsActive", function(value) if type(value) == "boolean" then badgesNotificationsActive = value end end)
-else
-	StarterGui:RegisterSetCore("PointsNotificationsActive", function() end)
-	StarterGui:RegisterSetCore("BadgesNotificationsActive", function() end)
-end
+StarterGui:RegisterSetCore("PointsNotificationsActive", function(value) if type(value) == "boolean" then pointsNotificationsActive = value end end)
+StarterGui:RegisterSetCore("BadgesNotificationsActive", function(value) if type(value) == "boolean" then badgesNotificationsActive = value end end)
 
 StarterGui:RegisterGetCore("PointsNotificationsActive", function() return pointsNotificationsActive end)
 StarterGui:RegisterGetCore("BadgesNotificationsActive", function() return badgesNotificationsActive end)
 
-if allowSendNotifications then
-	StarterGui:RegisterSetCore("SendNotification", createDeveloperNotification)
-else
-	StarterGui:RegisterSetCore("SendNotification", function() end)
-end
+StarterGui:RegisterSetCore("SendNotification", createDeveloperNotification)
 
 
 if not isTenFootInterface then
@@ -932,4 +917,3 @@ if Platform == Enum.Platform.XBoxOne then
 		end
 	end
 end
-

--- a/CoreScriptsRoot/CoreScripts/Topbar.lua
+++ b/CoreScriptsRoot/CoreScripts/Topbar.lua
@@ -6,9 +6,6 @@
 
 --[[ FFLAG VALUES ]]
 
-local defeatableTopbarSuccess, defeatableTopbarFlagValue = pcall(function() return settings():GetFFlag("EnableSetCoreTopbarEnabled") end)
-local defeatableTopbar = (defeatableTopbarSuccess and defeatableTopbarFlagValue == true)
-
 local vr3dGuisSuccess, vr3dGuisFlagValue = pcall(function() return settings():GetFFlag("RenderUserGuiIn3DSpace") end)
 local vr3dGuis = (vr3dGuisSuccess and vr3dGuisFlagValue == true)
 
@@ -17,21 +14,6 @@ local newNotificationPath = getNewNotificationPathSuccess and newNotificationPat
 
 local newChatVisiblePropSuccess, newChatVisiblePropValue =  pcall(function() return settings():GetFFlag("ChatVisiblePropertyEnabled") end)
 local newChatVisibleProp = (newChatVisiblePropSuccess and newChatVisiblePropValue)
-
-local showHealthWhenDamagedSuccess, showHealthWhenDamagedValue = pcall(function() return settings():GetFFlag("OnlyShowHealthWhenDamaged") end)
-local onlyShowHealthWhenDamagedEnabled = showHealthWhenDamagedSuccess and showHealthWhenDamagedValue
-
-local showVisibleAgeSuccess, showVisibleAgeValue = pcall(function() return settings():GetFFlag("CoreScriptShowVisibleAge") end)
-local showVisibleAgeEnabled = showVisibleAgeSuccess and showVisibleAgeValue
-
-local showVisibleAgeXboxSuccess, showVisibleAgeXboxValue = pcall(function() return settings():GetFFlag("CoreScriptShowVisibleAgeXbox") end)
-local showVisibleAgeEnabledXbox = showVisibleAgeXboxSuccess and showVisibleAgeXboxValue
-
-local showVisibleAgeV2Success, showVisibleAgeV2Value = pcall(function() return settings():GetFFlag("CoreScriptShowVisibleAgeV2") end)
-local showVisibleAgeV2Enabled = showVisibleAgeV2Success and showVisibleAgeV2Value
-
-local chatPrivacySettingSuccess, chatPrivacySettingValue = pcall(function() return settings():GetFFlag("UserChatPrivacySetting") end)
-local chatPrivacySettingEnabled = chatPrivacySettingSuccess and chatPrivacySettingValue
 
 --[[ END OF FFLAG VALUES ]]
 
@@ -62,13 +44,11 @@ local function isTopbarEnabled()
 	return topbarEnabled and not InputService.VREnabled
 end
 
-if defeatableTopbar then
-	StarterGui:RegisterSetCore("TopbarEnabled", function(enabled) -- registers a placeholder setcore function that keeps track of players enabling/disabling the topbar before it's ready.
-		if type(enabled) == "boolean" then
-			topbarEnabled = enabled
-		end
-	end)
-end
+StarterGui:RegisterSetCore("TopbarEnabled", function(enabled) -- registers a placeholder setcore function that keeps track of players enabling/disabling the topbar before it's ready.
+	if type(enabled) == "boolean" then
+		topbarEnabled = enabled
+	end
+end)
 local lookMenuEnabled = true
 
 local settingsActive = false
@@ -82,14 +62,14 @@ end
 
 local canChat = true
 
-local accountTypeText = showVisibleAgeV2Enabled and "Account: <13" or "Account: Under 13 yrs"
+local accountTypeText = "Account: <13"
 local accountTypeTextShort = "<13"
 
 function calculateAccountText()
-	accountTypeText = showVisibleAgeV2Enabled and "Account: 13+" or "Account: Over 13 yrs"
+	accountTypeText = "Account: 13+"
 	accountTypeTextShort = "13+"
 	if Player:GetUnder13() then
-		accountTypeText = showVisibleAgeV2Enabled and "Account: <13" or "Account: Under 13 yrs"
+		accountTypeText = "Account: <13"
 		accountTypeTextShort = "<13"
 	end
 end
@@ -640,7 +620,7 @@ local function createNormalHealthBar()
 	local username = Util.Create'TextLabel'{
 		Name = "Username";
 		Text = Player.Name;
-		Size = UDim2.new(1, -14, 0, showVisibleAgeEnabled and 18 or 22);
+		Size = UDim2.new(1, -14, 0, 18);
 		Position = UDim2.new(0, 7, 0, 0);
 		Font = Enum.Font.SourceSansBold;
 		FontSize = Enum.FontSize.Size14;
@@ -652,23 +632,19 @@ local function createNormalHealthBar()
 	};
 
 
-	local accountType = nil
-
-	if showVisibleAgeEnabled then
-		accountType = Util.Create'TextLabel'{
-			Name = "AccountType";
-			Text = accountTypeText;
-			Size = UDim2.new(1, -14, 0, 9);
-			Position = UDim2.new(0, 7, 0, 20);
-			Font = Enum.Font.SourceSans;
-			TextSize = 11;
-			BackgroundTransparency = 1;
-			TextColor3 = TopbarConstants.FONT_COLOR;
-			TextYAlignment = Enum.TextYAlignment.Bottom;
-			TextXAlignment = Enum.TextXAlignment.Left;
-			Parent = container;
-		};
-	end
+	local accountType = Util.Create'TextLabel'{
+		Name = "AccountType";
+		Text = accountTypeText;
+		Size = UDim2.new(1, -14, 0, 9);
+		Position = UDim2.new(0, 7, 0, 20);
+		Font = Enum.Font.SourceSans;
+		TextSize = 11;
+		BackgroundTransparency = 1;
+		TextColor3 = TopbarConstants.FONT_COLOR;
+		TextYAlignment = Enum.TextYAlignment.Bottom;
+		TextXAlignment = Enum.TextXAlignment.Left;
+		Parent = container;
+	};
 
 	spawn(function()
 		wait()
@@ -679,7 +655,7 @@ local function createNormalHealthBar()
 	local healthContainer = Util.Create'Frame'{
 		Name = "HealthContainer";
 		Size = UDim2.new(1, -14, 0, 3);
-		Position = UDim2.new(0, 7, 1, showVisibleAgeEnabled and -7 or -9);
+		Position = UDim2.new(0, 7, 1, -7);
 		BorderSizePixel = 0;
 		BackgroundColor3 = TopbarConstants.HEALTH_BACKGROUND_COLOR;
 		Parent = container;
@@ -797,38 +773,13 @@ local function CreateUsernameHealthMenuItem()
 	local function UpdateHealthVisible()
 		local isEnabled = HealthBarEnabled and CurrentHumanoid and CurrentHumanoid.Health ~= CurrentHumanoid.MaxHealth
 		healthContainer.Visible = isEnabled
-		if showVisibleAgeEnabled then
-			if showVisibleAgeV2Enabled then
-				return
-			end
-			if isEnabled then
-				username.Size = UDim2.new(1, -14, 0, 18);
-				username.TextYAlignment = Enum.TextYAlignment.Bottom;
-				accountType.Position = UDim2.new(0, 7, 0, 20);
-			else
-				username.Size = UDim2.new(1, -14, 1, -12);
-				username.TextYAlignment = Enum.TextYAlignment.Center;
-				accountType.Size = UDim2.new(1, -14, 0, 9);
-				accountType.Position = UDim2.new(0, 7, 1, -10);
-			end
-		else
-			if isEnabled then
-				username.Size = UDim2.new(1, -14, 0, 22);
-				username.TextYAlignment = Enum.TextYAlignment.Bottom;
-			else
-				username.Size = UDim2.new(1, -14, 1, 0);
-				username.TextYAlignment = Enum.TextYAlignment.Center;
-			end
-		end
 	end
 
 	local function OnHumanoidAdded(humanoid)
 		CurrentHumanoid = humanoid
 		local lastHealth = humanoid.Health
 		local function OnHumanoidHealthChanged(health)
-			if onlyShowHealthWhenDamagedEnabled then
-				UpdateHealthVisible()
-			end
+			UpdateHealthVisible()
 			if humanoid then
 				local healthDelta = lastHealth - health
 				local healthPercent = health / humanoid.MaxHealth
@@ -876,27 +827,14 @@ local function CreateUsernameHealthMenuItem()
 
 	rawset(this, "SetHealthbarEnabled",
 		function(self, enabled)
-			if onlyShowHealthWhenDamagedEnabled then
-				HealthBarEnabled = enabled
-				UpdateHealthVisible()
-			else
-				healthContainer.Visible = enabled
-				if enabled then
-					username.Size = UDim2.new(1, -14, 0, 22);
-					username.TextYAlignment = Enum.TextYAlignment.Bottom;
-				else
-					username.Size = UDim2.new(1, -14, 1, 0);
-					username.TextYAlignment = Enum.TextYAlignment.Center;
-				end
-			end
+			HealthBarEnabled = enabled
+			UpdateHealthVisible()
 		end)
 
 	rawset(this, "SetNameVisible",
 		function(self, visible)
 			username.Visible = visible
-			if showVisibleAgeEnabled then
-				accountType.Visible = visible
-			end
+			accountType.Visible = visible
 		end)
 
 	-- Don't need to disconnect this one because we never reconnect it.
@@ -1714,45 +1652,27 @@ local function CreateNoTopBarAccountType()
 		BackgroundTransparency = 1;
 	}
 
-	local bubble = nil
-
-	if not showVisibleAgeV2Enabled then
-		bubble = Util.Create'ImageButton'
-		{
-			Name = "AccountTypeBubble";
-			Size = UDim2.new(1, -10, 1, -16);
-			Position = UDim2.new(0, 10, 0, 8);
-			AutoButtonColor = false;
-			Image = "rbxasset://textures/ui/TopBar/Round.png";
-			ScaleType = Enum.ScaleType.Slice;
-			SliceCenter = Rect.new(10, 10, 10, 10);
-			ImageTransparency = 0;
-			BackgroundTransparency = 1;
-			Parent = container;
-		}
-	end
-
 	local accountTypeTextLabel = Util.Create'TextLabel'{
 		Name = "AccountTypeText";
-		Text = showVisibleAgeV2Enabled and accountTypeTextShort or accountTypeText;
+		Text = accountTypeTextShort;
 		Size = UDim2.new(1, -12, 1, -12);
-		Position = UDim2.new(0, showVisibleAgeV2Enabled and 0 or 6, 0, 6);
+		Position = UDim2.new(0, 0, 0, 6);
 		Font = Enum.Font.SourceSansBold;
 		FontSize = Enum.FontSize.Size14;
 		BackgroundTransparency = 1;
 		TextColor3 = TopbarConstants.FONT_COLOR;
 		TextYAlignment = Enum.TextYAlignment.Center;
 		TextXAlignment = Enum.TextXAlignment.Left;
-		Parent = showVisibleAgeV2Enabled and container or bubble;
+		Parent = container;
 	};
 
 	spawn(function()
 		wait()
 		calculateAccountText()
-		accountTypeTextLabel.Text = showVisibleAgeV2Enabled and accountTypeTextShort or accountTypeText
+		accountTypeTextLabel.Text = accountTypeTextShort
 		if container.Visible then
 			local textBounds = accountTypeTextLabel.TextBounds.X
-			local containerSize = showVisibleAgeV2Enabled and textBounds or 22 + textBounds
+			local containerSize = textBounds
 			container.Size = UDim2.new(0, containerSize, 1, 0)
 		end
 	end)
@@ -1764,7 +1684,7 @@ local function CreateNoTopBarAccountType()
 		else
 			container.Visible = true
 			local textBounds = accountTypeTextLabel.TextBounds.X
-			local containerSize = showVisibleAgeV2Enabled and textBounds or 22 + textBounds
+			local containerSize = textBounds
 			container.Size = UDim2.new(0, containerSize, 1, 0)
 		end
 	end
@@ -1787,17 +1707,13 @@ local Menubar3D = CreateMenuBar3D(BarAlignmentEnum.Left, TopbarPanel3D)
 local settingsIcon = CreateSettingsIcon(TopBar)
 local noTopBarAccountType = nil
 
-if isTenFootInterface and showVisibleAgeEnabledXbox then
+if isTenFootInterface then
 	spawn(function()
 		wait()
 		calculateAccountText()
-		if showVisibleAgeV2Enabled then
-			TenFootInterface:CreateAccountTypeV2(accountTypeTextShort)
-		else
-			TenFootInterface:CreateAccountType(accountTypeText)
-		end
+		TenFootInterface:CreateAccountType(accountTypeTextShort)
 	end)
-elseif not isTenFootInterface and showVisibleAgeEnabled then
+elseif not isTenFootInterface then
 	noTopBarAccountType = CreateNoTopBarAccountType()
 end
 
@@ -2122,37 +2038,31 @@ local function OnVREnabled(prop)
 end
 UISChanged = InputService.Changed:connect(OnVREnabled)
 
-if defeatableTopbar then
-	topbarEnabledChanged() -- if it was set before this point, enable/disable it now
-	StarterGui:RegisterSetCore("TopbarEnabled", function(enabled)
-		if type(enabled) == "boolean" then
-			topbarEnabled = enabled
-			topbarEnabledChanged()
-		end
-	end)
-else
-	topbarEnabledChanged()
-end
+topbarEnabledChanged() -- if it was set before this point, enable/disable it now
+StarterGui:RegisterSetCore("TopbarEnabled", function(enabled)
+	if type(enabled) == "boolean" then
+		topbarEnabled = enabled
+		topbarEnabledChanged()
+	end
+end)
 
-if chatPrivacySettingEnabled then
-	spawn(function()
-		local success, localUserCanChat = pcall(function()
-			return ChatService:CanUserChatAsync(Player.UserId)
-		end)
-		canChat = RunService:IsStudio() or (success and localUserCanChat)
-		if canChat == false then
-			if Util.IsTouchDevice() or ChatModule:IsBubbleChatOnly() then
-				if chatIcon then
-					LeftMenubar:RemoveItem(chatIcon)
-				end
-				if ChatModule:IsBubbleChatOnly() and mobileShowChatIcon then
-					LeftMenubar:RemoveItem(mobileShowChatIcon)
-				end
-			end
-			ChatModule:SetVisible(false)
-		end
+spawn(function()
+	local success, localUserCanChat = pcall(function()
+		return ChatService:CanUserChatAsync(Player.UserId)
 	end)
-end
+	canChat = RunService:IsStudio() or (success and localUserCanChat)
+	if canChat == false then
+		if Util.IsTouchDevice() or ChatModule:IsBubbleChatOnly() then
+			if chatIcon then
+				LeftMenubar:RemoveItem(chatIcon)
+			end
+			if ChatModule:IsBubbleChatOnly() and mobileShowChatIcon then
+				LeftMenubar:RemoveItem(mobileShowChatIcon)
+			end
+		end
+		ChatModule:SetVisible(false)
+	end
+end)
 
 -- Hook-up coregui changing
 StarterGui.CoreGuiChangedSignal:connect(OnCoreGuiChanged)

--- a/CoreScriptsRoot/Modules/Chat.lua
+++ b/CoreScriptsRoot/Modules/Chat.lua
@@ -69,9 +69,6 @@ local GameSettings = Settings.GameSettings
 local playerDropDownEnabledSuccess, playerDropDownEnabledFlagValue = pcall(function() return settings():GetFFlag("PlayerDropDownEnabled") end)
 local IsPlayerDropDownEnabled = playerDropDownEnabledSuccess and playerDropDownEnabledFlagValue
 
-local getMoveChatSuccess, moveChatActiveValue = pcall(function() return settings():GetFFlag("SetCoreMoveChat") end)
-local allowMoveChat = getMoveChatSuccess and moveChatActiveValue
-
 local getDisableChatBarSuccess, disableChatBarValue = pcall(function() return settings():GetFFlag("SetCoreDisableChatBar") end)
 local allowDisableChatBar = getDisableChatBarSuccess and disableChatBarValue
 
@@ -2686,34 +2683,28 @@ local function CreateChat()
         return not PlayersService.ClassicChat and PlayersService.BubbleChat
       end
 
-      if allowMoveChat then
-        StarterGui:RegisterSetCore("ChatWindowPosition", 	function(value)
-            if this.ChatWindowWidget and this.ChatBarWidget then
-              value = isUDim2Value(value)
-              if value ~= nil and not isBubbleChatOn() then
-                chatRepositioned = true -- Prevent chat from moving back to the original position on screen resolution change
-                this.ChatWindowWidget.ChatContainer.Position = value
-                this.ChatBarWidget.ChatBarContainer.Position = value + UDim2.new(0, 0, this.ChatWindowWidget.ChatContainer.Size.Y.Scale, this.ChatWindowWidget.ChatContainer.Size.Y.Offset + 2)
-              end
+      StarterGui:RegisterSetCore("ChatWindowPosition", 	function(value)
+          if this.ChatWindowWidget and this.ChatBarWidget then
+            value = isUDim2Value(value)
+            if value ~= nil and not isBubbleChatOn() then
+              chatRepositioned = true -- Prevent chat from moving back to the original position on screen resolution change
+              this.ChatWindowWidget.ChatContainer.Position = value
+              this.ChatBarWidget.ChatBarContainer.Position = value + UDim2.new(0, 0, this.ChatWindowWidget.ChatContainer.Size.Y.Scale, this.ChatWindowWidget.ChatContainer.Size.Y.Offset + 2)
             end
-          end)
+          end
+        end)
 
-        StarterGui:RegisterSetCore("ChatWindowSize", 	function(value)
-            if this.ChatWindowWidget and this.ChatBarWidget then
-              value = isUDim2Value(value)
-              if value ~= nil and not isBubbleChatOn() then
-                chatRepositioned = true
-                this.ChatWindowWidget.ChatContainer.Size = value
-                this.ChatBarWidget.ChatBarContainer.Size = UDim2.new(this.ChatWindowWidget.ChatContainer.Size.X.Scale, this.ChatWindowWidget.ChatContainer.Size.X.Offset, this.ChatBarWidget.ChatBarContainer.Size.Y.Scale, this.ChatBarWidget.ChatBarContainer.Size.Y.Offset)
-                this.ChatBarWidget.ChatBarContainer.Position = this.ChatWindowWidget.ChatContainer.Position + UDim2.new(0, 0, this.ChatWindowWidget.ChatContainer.Size.Y.Scale, this.ChatWindowWidget.ChatContainer.Size.Y.Offset + 2)
-              end
+      StarterGui:RegisterSetCore("ChatWindowSize", 	function(value)
+          if this.ChatWindowWidget and this.ChatBarWidget then
+            value = isUDim2Value(value)
+            if value ~= nil and not isBubbleChatOn() then
+              chatRepositioned = true
+              this.ChatWindowWidget.ChatContainer.Size = value
+              this.ChatBarWidget.ChatBarContainer.Size = UDim2.new(this.ChatWindowWidget.ChatContainer.Size.X.Scale, this.ChatWindowWidget.ChatContainer.Size.X.Offset, this.ChatBarWidget.ChatBarContainer.Size.Y.Scale, this.ChatBarWidget.ChatBarContainer.Size.Y.Offset)
+              this.ChatBarWidget.ChatBarContainer.Position = this.ChatWindowWidget.ChatContainer.Position + UDim2.new(0, 0, this.ChatWindowWidget.ChatContainer.Size.Y.Scale, this.ChatWindowWidget.ChatContainer.Size.Y.Offset + 2)
             end
-          end)
-
-      else
-        StarterGui:RegisterSetCore("ChatWindowPosition", 	function() end)
-        StarterGui:RegisterSetCore("ChatWindowSize",		function() end)
-      end
+          end
+        end)
 
       StarterGui:RegisterGetCore("ChatWindowPosition", 	function()
           if this.ChatWindowWidget then

--- a/CoreScriptsRoot/Modules/ChatSelector.lua
+++ b/CoreScriptsRoot/Modules/ChatSelector.lua
@@ -151,6 +151,7 @@ end
 local function NonFunc() end
 StarterGui:RegisterSetCore("ChatMakeSystemMessage", MakeSystemMessageQueueingFunction)
 StarterGui:RegisterSetCore("ChatWindowPosition", NonFunc)
+StarterGui:RegisterGetCore("ChatWindowPosition", NonFunc)
 StarterGui:RegisterSetCore("ChatWindowSize", NonFunc)
 StarterGui:RegisterGetCore("ChatWindowSize", NonFunc)
 StarterGui:RegisterSetCore("ChatBarDisabled", NonFunc)

--- a/CoreScriptsRoot/Modules/ChatSelector.lua
+++ b/CoreScriptsRoot/Modules/ChatSelector.lua
@@ -152,20 +152,17 @@ local function NonFunc() end
 StarterGui:RegisterSetCore("ChatMakeSystemMessage", MakeSystemMessageQueueingFunction)
 StarterGui:RegisterSetCore("ChatWindowPosition", NonFunc)
 StarterGui:RegisterSetCore("ChatWindowSize", NonFunc)
-StarterGui:RegisterGetCore("ChatWindowPosition", NonFunc)
 StarterGui:RegisterGetCore("ChatWindowSize", NonFunc)
 StarterGui:RegisterSetCore("ChatBarDisabled", NonFunc)
 StarterGui:RegisterGetCore("ChatBarDisabled", NonFunc)
 
-local readChatActiveFlagSuccess, chatActiveEnabled = pcall(function() return settings():GetFFlag("CorescriptSetCoreChatActiveEnabled") end)
-if readChatActiveFlagSuccess and chatActiveEnabled then
-	StarterGui:RegisterGetCore("ChatActive", function()
-		return interface:GetVisibility()
-	end)
-	StarterGui:RegisterSetCore("ChatActive", function(visible)
-		return interface:SetVisible(visible)
-	end)
-end
+
+StarterGui:RegisterGetCore("ChatActive", function()
+	return interface:GetVisibility()
+end)
+StarterGui:RegisterSetCore("ChatActive", function(visible)
+	return interface:SetVisible(visible)
+end)
 
 
 local function ConnectSignals(useModule, interface, sigName)

--- a/CoreScriptsRoot/Modules/NewChat.lua
+++ b/CoreScriptsRoot/Modules/NewChat.lua
@@ -16,9 +16,6 @@ local BubbleChatEnabled = PlayersService.BubbleChat
 
 local Util = require(RobloxGui.Modules.ChatUtil)
 
-local readFlagSuccess, flagEnabled = pcall(function() return settings():GetFFlag("CorescriptNewChatSetCoresEnabled") end)
-local EnableChatSetCoreAPIs = readFlagSuccess and flagEnabled
-
 local moduleApiTable = {}
 do
 		local ChatWindowState =
@@ -31,8 +28,6 @@ do
 
 		local communicationsConnections = {}
 		local eventConnections = {}
-
-		local MakeSystemMessageCache = {} -- Remove with CorescriptNewChatSetCoresEnabled
 
 		local SetCoreCache = {}
 
@@ -176,17 +171,6 @@ do
 			DispatchEvent("SpecialKeyPressed", key, modifiers)
 		end)
 
-		if EnableChatSetCoreAPIs == false then
-			StarterGui:RegisterSetCore("ChatMakeSystemMessage", function(data)
-				local event = FindInCollectionByKeyAndType(communicationsConnections.SetCore, "ChatMakeSystemMessage", "BindableEvent")
-				if (event) then
-					event:Fire(data)
-				else
-					table.insert(MakeSystemMessageCache, data)
-				end
-			end)
-		end
-
 		function DoConnectSetCore(setCoreName)
 			StarterGui:RegisterSetCore(setCoreName, function(data)
 				local event = FindInCollectionByKeyAndType(communicationsConnections.SetCore, setCoreName, "BindableEvent")
@@ -201,12 +185,10 @@ do
 			end)
 		end
 
-		if EnableChatSetCoreAPIs then
-			DoConnectSetCore("ChatMakeSystemMessage")
-			DoConnectSetCore("ChatWindowPosition")
-			DoConnectSetCore("ChatWindowSize")
-			DoConnectSetCore("ChatBarDisabled")
-		end
+		DoConnectSetCore("ChatMakeSystemMessage")
+		DoConnectSetCore("ChatWindowPosition")
+		DoConnectSetCore("ChatWindowSize")
+		DoConnectSetCore("ChatBarDisabled")
 
 		DoConnectGetCore("ChatWindowPosition")
 		DoConnectGetCore("ChatWindowSize")
@@ -275,17 +257,6 @@ do
 					communicationsConnections.SetCore = {}
 					communicationsConnections.GetCore = {}
 
-					if EnableChatSetCoreAPIs == false then
-						local event = FindInCollectionByKeyAndType(setCoreCollection, "ChatMakeSystemMessage", "BindableEvent")
-						if (event) then
-							communicationsConnections.SetCore.ChatMakeSystemMessage = event
-							for i, messageData in pairs(MakeSystemMessageCache) do
-								pcall(function() StarterGui:SetCore("ChatMakeSystemMessage", messageData) end)
-							end
-							MakeSystemMessageCache = {}
-						end
-					end
-
 					local function addSetCore(setCoreName)
 						local event = FindInCollectionByKeyAndType(setCoreCollection, setCoreName, "BindableEvent")
 						if (event) then
@@ -299,12 +270,10 @@ do
 						end
 					end
 
-					if EnableChatSetCoreAPIs then
-						addSetCore("ChatMakeSystemMessage")
-						addSetCore("ChatWindowPosition")
-						addSetCore("ChatWindowSize")
-						addSetCore("ChatBarDisabled")
-					end
+					addSetCore("ChatMakeSystemMessage")
+					addSetCore("ChatWindowPosition")
+					addSetCore("ChatWindowSize")
+					addSetCore("ChatBarDisabled")
 
 					communicationsConnections.GetCore.ChatWindowPosition = FindInCollectionByKeyAndType(getCoreCollection, "ChatWindowPosition", "BindableFunction")
 					communicationsConnections.GetCore.ChatWindowSize = FindInCollectionByKeyAndType(getCoreCollection, "ChatWindowSize", "BindableFunction")

--- a/CoreScriptsRoot/Modules/PlayerDropDown.lua
+++ b/CoreScriptsRoot/Modules/PlayerDropDown.lua
@@ -552,54 +552,49 @@ end
 
 --- GetCore Blocked/Muted/Friended events.
 
-local readFlagSuccess, flagEnabled = pcall(function() return settings():GetFFlag("CorescriptGetCorePlayerEvents") end)
-local CorescriptPlayerEventsEnabled = readFlagSuccess and flagEnabled
+local PlayerBlockedEvent = Instance.new("BindableEvent")
+local PlayerUnblockedEvent = Instance.new("BindableEvent")
+local PlayerMutedEvent = Instance.new("BindableEvent")
+local PlayerUnMutedEvent = Instance.new("BindableEvent")
+local PlayerFriendedEvent = Instance.new("BindableEvent")
+local PlayerUnFriendedEvent = Instance.new("BindableEvent")
 
-if CorescriptPlayerEventsEnabled then
-	local PlayerBlockedEvent = Instance.new("BindableEvent")
-	local PlayerUnblockedEvent = Instance.new("BindableEvent")
-	local PlayerMutedEvent = Instance.new("BindableEvent")
-	local PlayerUnMutedEvent = Instance.new("BindableEvent")
-	local PlayerFriendedEvent = Instance.new("BindableEvent")
-	local PlayerUnFriendedEvent = Instance.new("BindableEvent")
-
-	BlockStatusChanged:connect(function(userId, isBlocked)
-		local player = PlayersService:GetPlayerByUserId(userId)
-		if player then
-			if isBlocked then
-				PlayerBlockedEvent:Fire(player)
-			else
-				PlayerUnblockedEvent:Fire(player)
-			end
+BlockStatusChanged:connect(function(userId, isBlocked)
+	local player = PlayersService:GetPlayerByUserId(userId)
+	if player then
+		if isBlocked then
+			PlayerBlockedEvent:Fire(player)
+		else
+			PlayerUnblockedEvent:Fire(player)
 		end
-	end)
+	end
+end)
 
-	MuteStatusChanged:connect(function(userId, isMuted)
-		local player = PlayersService:GetPlayerByUserId(userId)
-		if player then
-			if isMuted then
-				PlayerMutedEvent:Fire(player)
-			else
-				PlayerUnMutedEvent:Fire(player)
-			end
+MuteStatusChanged:connect(function(userId, isMuted)
+	local player = PlayersService:GetPlayerByUserId(userId)
+	if player then
+		if isMuted then
+			PlayerMutedEvent:Fire(player)
+		else
+			PlayerUnMutedEvent:Fire(player)
 		end
-	end)
+	end
+end)
 
-	LocalPlayer.FriendStatusChanged:connect(function(player, friendStatus)
-		if friendStatus == Enum.FriendStatus.Friend then
-			PlayerFriendedEvent:Fire(player)
-		elseif friendStatus == Enum.FriendStatus.NotFriend then
-			PlayerUnFriendedEvent:Fire(player)
-		end
-	end)
+LocalPlayer.FriendStatusChanged:connect(function(player, friendStatus)
+	if friendStatus == Enum.FriendStatus.Friend then
+		PlayerFriendedEvent:Fire(player)
+	elseif friendStatus == Enum.FriendStatus.NotFriend then
+		PlayerUnFriendedEvent:Fire(player)
+	end
+end)
 
-	StarterGui:RegisterGetCore("PlayerBlockedEvent", function() return PlayerBlockedEvent end)
-	StarterGui:RegisterGetCore("PlayerUnblockedEvent", function() return PlayerUnblockedEvent end)
-	StarterGui:RegisterGetCore("PlayerMutedEvent", function() return PlayerMutedEvent end)
-	StarterGui:RegisterGetCore("PlayerUnmutedEvent", function() return PlayerUnMutedEvent end)
-	StarterGui:RegisterGetCore("PlayerFriendedEvent", function() return PlayerFriendedEvent end)
-	StarterGui:RegisterGetCore("PlayerUnfriendedEvent", function() return PlayerUnFriendedEvent end)
-end
+StarterGui:RegisterGetCore("PlayerBlockedEvent", function() return PlayerBlockedEvent end)
+StarterGui:RegisterGetCore("PlayerUnblockedEvent", function() return PlayerUnblockedEvent end)
+StarterGui:RegisterGetCore("PlayerMutedEvent", function() return PlayerMutedEvent end)
+StarterGui:RegisterGetCore("PlayerUnmutedEvent", function() return PlayerUnMutedEvent end)
+StarterGui:RegisterGetCore("PlayerFriendedEvent", function() return PlayerFriendedEvent end)
+StarterGui:RegisterGetCore("PlayerUnfriendedEvent", function() return PlayerUnFriendedEvent end)
 
 do
 	moduleApiTable.FollowerStatusChanged = createSignal()

--- a/CoreScriptsRoot/Modules/Server/ClientChat/ChatMain.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/ChatMain.lua
@@ -92,12 +92,6 @@ while not LocalPlayer do
 	LocalPlayer = Players.LocalPlayer
 end
 
-local chatPrivacySettingsSuccess, chatPrivacySettingsValue = pcall(function() return UserSettings():IsUserFeatureEnabled("UserChatPrivacySetting") end)
-local chatPrivacySettingsEnabled = true
-if chatPrivacySettingsSuccess then
-	chatPrivacySettingsEnabled = chatPrivacySettingsValue
-end
-
 local canChat = true
 
 local ChatDisplayOrder = 6
@@ -1046,16 +1040,14 @@ spawn(function()
 	end
 end)
 
-if chatPrivacySettingsEnabled then
-	spawn(function()
-		local success, canLocalUserChat = pcall(function()
-			return Chat:CanUserChatAsync(LocalPlayer.UserId)
-		end)
-		if success then
-			canChat = RunService:IsStudio() or canLocalUserChat
-		end
+spawn(function()
+	local success, canLocalUserChat = pcall(function()
+		return Chat:CanUserChatAsync(LocalPlayer.UserId)
 	end)
-end
+	if success then
+		canChat = RunService:IsStudio() or canLocalUserChat
+	end
+end)
 
 local initData = EventFolder.GetInitDataRequest:InvokeServer()
 

--- a/CoreScriptsRoot/Modules/Server/ClientChat/ChatWindowInstaller.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/ChatWindowInstaller.lua
@@ -34,16 +34,8 @@ local function GetBoolValue(parent, name, defaultValue)
 	return defaultValue
 end
 
-local function loadDefaultChatDisabled()
-	local readFlagSuccess, flagEnabled = pcall(function() return settings():GetFFlag("LoadDefaultChatEnabled") end)
-	if readFlagSuccess and flagEnabled then
-		return not ChatService.LoadDefaultChat
-	end
-	return false
-end
-
 local function Install()
-	if loadDefaultChatDisabled() then
+	if not ChatService.LoadDefaultChat then
 		return
 	end
 

--- a/CoreScriptsRoot/Modules/Server/ServerChat/ChatChannel.lua
+++ b/CoreScriptsRoot/Modules/Server/ServerChat/ChatChannel.lua
@@ -58,20 +58,8 @@ function methods:SendMessageObjToFilters(message, messageObj, fromSpeaker)
 	return newMessage
 end
 
-function ChatSettingsEnabled()
-	local chatPrivacySettingsSuccess, chatPrivacySettingsValue = pcall(function() return UserSettings():IsUserFeatureEnabled("UserChatPrivacySetting") end)
-	local chatPrivacySettingsEnabled = true
-	if chatPrivacySettingsSuccess then
-		chatPrivacySettingsEnabled = chatPrivacySettingsValue
-	end
-	return chatPrivacySettingsEnabled
-end
-
 function methods:CanCommunicateByUserId(userId1, userId2)
 	if RunService:IsStudio() then
-		return true
-	end
-	if ChatSettingsEnabled() == false then
 		return true
 	end
 	-- UserId is set as 0 for non player speakers.

--- a/CoreScriptsRoot/Modules/Server/ServerChat/ChatServiceInstaller.lua
+++ b/CoreScriptsRoot/Modules/Server/ServerChat/ChatServiceInstaller.lua
@@ -32,21 +32,11 @@ local function GetBoolValue(parent, name, defaultValue)
 	return defaultValue
 end
 
-local function loadDefaultChatDisabled()
-	local readFlagSuccess, flagEnabled = pcall(function() return settings():GetFFlag("LoadDefaultChatEnabled") end)
-	if readFlagSuccess and flagEnabled then
-		return not ChatService.LoadDefaultChat
-	end
-	return false
-end
 
 local function Install()
-	if loadDefaultChatDisabled() then
+	if not ChatService.LoadDefaultChat then
 		return
 	end
-
-	local readFlagSuccess, flagEnabled = pcall(function() return settings():GetFFlag("CorescriptChatInsertDefaultBools") end)
-	local UseInsertDefaultBools = readFlagSuccess and flagEnabled
 
 	local chatServiceRunnerArchivable = true
 	local ChatServiceRunner = installDirectory:FindFirstChild(runnerScriptName)
@@ -66,30 +56,21 @@ local function Install()
 		ChatModules.Name = "ChatModules"
 		ChatModules.Archivable = false
 
-		if UseInsertDefaultBools then
-			local InsertDefaults = Instance.new("BoolValue")
-			InsertDefaults.Name = "InsertDefaultModules"
-			InsertDefaults.Value = true
-			InsertDefaults.Parent = ChatModules
-		else
-			local defaultChatModules = script.Parent.DefaultChatModules:GetChildren()		  		local defaultChatModules = script.Parent.DefaultChatModules:GetChildren()
-  		for i = 1, #defaultChatModules do
-				LoadModule(script.Parent.DefaultChatModules, defaultChatModules[i].Name, ChatModules)
-			end
-		end
+		local InsertDefaults = Instance.new("BoolValue")
+		InsertDefaults.Name = "InsertDefaultModules"
+		InsertDefaults.Value = true
+		InsertDefaults.Parent = ChatModules
 
 		ChatModules.Parent = installDirectory
 	end
 
-	if UseInsertDefaultBools then
-		local shouldInsertDefaultModules = GetBoolValue(ChatModules, "InsertDefaultModules", false)
+	local shouldInsertDefaultModules = GetBoolValue(ChatModules, "InsertDefaultModules", false)
 
-		if shouldInsertDefaultModules then
-			local defaultChatModules = script.Parent.DefaultChatModules:GetChildren()
-			for i = 1, #defaultChatModules do
-				if not ChatModules:FindFirstChild(defaultChatModules[i].Name) then
-					LoadModule(script.Parent.DefaultChatModules, defaultChatModules[i].Name, ChatModules)
-				end
+	if shouldInsertDefaultModules then
+		local defaultChatModules = script.Parent.DefaultChatModules:GetChildren()
+		for i = 1, #defaultChatModules do
+			if not ChatModules:FindFirstChild(defaultChatModules[i].Name) then
+				LoadModule(script.Parent.DefaultChatModules, defaultChatModules[i].Name, ChatModules)
 			end
 		end
 	end

--- a/CoreScriptsRoot/Modules/Server/ServerChat/DefaultChatModules/ChatMessageValidator.lua
+++ b/CoreScriptsRoot/Modules/Server/ServerChat/DefaultChatModules/ChatMessageValidator.lua
@@ -16,19 +16,7 @@ end
 
 local function Run(ChatService)
 
-	local function ChatSettingsEnabled()
-		local chatPrivacySettingsSuccess, chatPrivacySettingsValue = pcall(function() return UserSettings():IsUserFeatureEnabled("UserChatPrivacySetting") end)
-		local chatPrivacySettingsEnabled = true
-		if chatPrivacySettingsSuccess then
-			chatPrivacySettingsEnabled = chatPrivacySettingsValue
-		end
-		return chatPrivacySettingsEnabled
-	end
-
 	local function CanUserChat(playerObj)
-		if ChatSettingsEnabled() == false then
-			return true
-		end
 		if RunService:IsStudio() then
 			return true
 		end

--- a/CoreScriptsRoot/Modules/Server/ServerChat/DefaultChatModules/PrivateMessaging.lua
+++ b/CoreScriptsRoot/Modules/Server/ServerChat/DefaultChatModules/PrivateMessaging.lua
@@ -13,19 +13,7 @@ local errorExtraData = {ChatColor = errorTextColor}
 
 local function Run(ChatService)
 
-	local function ChatSettingsEnabled()
-		local chatPrivacySettingsSuccess, chatPrivacySettingsValue = pcall(function() return UserSettings():IsUserFeatureEnabled("UserChatPrivacySetting") end)
-		local chatPrivacySettingsEnabled = true
-		if chatPrivacySettingsSuccess then
-			chatPrivacySettingsEnabled = chatPrivacySettingsValue
-		end
-		return chatPrivacySettingsEnabled
-	end
-
 	local function CanCommunicate(fromSpeaker, toSpeaker)
-		if ChatSettingsEnabled() == false then
-			return true
-		end
 		if RunService:IsStudio() then
 			return true
 		end

--- a/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
@@ -50,8 +50,6 @@ local DeveloperConsoleModule = require(RobloxGui.Modules.DeveloperConsoleModule)
 
 local lastInputChangedCon = nil
 local chatWasVisible = false
-local userlistSuccess, userlistFlagValue = pcall(function() return settings():GetFFlag("UseUserListMenu") end)
-local useUserList = (userlistSuccess and userlistFlagValue == true)
 
 local resetButtonFlagSuccess, resetButtonFlagValue = pcall(function() return settings():GetFFlag("AllowResetButtonCustomization") end)
 local resetButtonCustomizationAllowed = (resetButtonFlagSuccess and resetButtonFlagValue == true)
@@ -525,7 +523,7 @@ local function CreateSettingsHub()
 			end
 			local barSize = this.HubBar.Size.Y.Offset
 			local extraSpace = bufferSize*2+barSize*2
-			local isPortrait = utility:IsPortrait() 
+			local isPortrait = utility:IsPortrait()
 
 			if isPortrait then
 				this.MenuContainer.Size = UDim2.new(1, 0, 1, 0)
@@ -615,7 +613,7 @@ local function CreateSettingsHub()
 				usePageSize = usableScreenHeight
 			end
 
-			if useUserList and not isTenFootInterface then
+			if not isTenFootInterface then
 				if isSmallTouchScreen then
 					this.PageViewClipper.Size = UDim2.new(
 						0,
@@ -1047,7 +1045,7 @@ local function CreateSettingsHub()
 				removeBottomBarBindings()
 				this:SwitchToPage(customStartPage, nil, 1, true)
 			else
-				if useUserList and not isTenFootInterface then
+				if not isTenFootInterface then
 					this:SwitchToPage(this.PlayersPage, nil, 1, true)
 				else
 					if this.HomePage then
@@ -1236,13 +1234,6 @@ local function CreateSettingsHub()
 	this.LeaveGamePage:SetHub(this)
 
 	-- full page initialization
-	if not useUserList then
-		if isSmallTouchScreen then
-			this.HomePage = require(RobloxGui.Modules.Settings.Pages.Home)
-			this.HomePage:SetHub(this)
-		end
-	end
-
 	this.GameSettingsPage = require(RobloxGui.Modules.Settings.Pages.GameSettings)
 	this.GameSettingsPage:SetHub(this)
 
@@ -1259,22 +1250,17 @@ local function CreateSettingsHub()
 		this.RecordPage:SetHub(this)
 	end
 
-	if useUserList and not isTenFootInterface then
+	if not isTenFootInterface then
 		this.PlayersPage = require(RobloxGui.Modules.Settings.Pages.Players)
 		this.PlayersPage:SetHub(this)
 	end
 
 	-- page registration
-	if useUserList and not isTenFootInterface then
+	if not isTenFootInterface then
 		this:AddPage(this.PlayersPage)
 	end
 	this:AddPage(this.ResetCharacterPage)
 	this:AddPage(this.LeaveGamePage)
-	if not useUserList then
-		if this.HomePage then
-			this:AddPage(this.HomePage)
-		end
-	end
 	this:AddPage(this.GameSettingsPage)
 	if this.ReportAbusePage then
 		this:AddPage(this.ReportAbusePage)
@@ -1284,7 +1270,7 @@ local function CreateSettingsHub()
 		this:AddPage(this.RecordPage)
 	end
 
-	if useUserList and not isTenFootInterface then
+	if not isTenFootInterface then
 		this:SwitchToPage(this.PlayerPage, true, 1)
 	else
 		if this.HomePage then

--- a/CoreScriptsRoot/Modules/Settings/SettingsHubOld.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsHubOld.lua
@@ -42,8 +42,6 @@ local DeveloperConsoleModule = require(RobloxGui.Modules.DeveloperConsoleModule)
 
 local lastInputChangedCon = nil
 local chatWasVisible = false
-local userlistSuccess, userlistFlagValue = pcall(function() return settings():GetFFlag("UseUserListMenu") end)
-local useUserList = (userlistSuccess and userlistFlagValue == true)
 
 local resetButtonFlagSuccess, resetButtonFlagValue = pcall(function() return settings():GetFFlag("AllowResetButtonCustomization") end)
 local resetButtonCustomizationAllowed = (resetButtonFlagSuccess and resetButtonFlagValue == true)
@@ -532,7 +530,7 @@ local function CreateSettingsHub()
 				end
 			end
 
-			if useUserList and not isTenFootInterface then
+			if not isTenFootInterface then
 				if isSmallTouchScreen then
 					this.PageViewClipper.Size = UDim2.new(
 						this.PageViewClipper.Size.X.Scale,
@@ -948,7 +946,7 @@ local function CreateSettingsHub()
 				removeBottomBarBindings()
 				this:SwitchToPage(customStartPage, nil, 1, true)
 			else
-				if useUserList and not isTenFootInterface then
+				if not isTenFootInterface then
 					this:SwitchToPage(this.PlayersPage, nil, 1, true)
 				else
 					if this.HomePage then
@@ -1136,13 +1134,6 @@ local function CreateSettingsHub()
 	this.LeaveGamePage:SetHub(this)
 
 	-- full page initialization
-	if not useUserList then
-		if isSmallTouchScreen then
-			this.HomePage = require(RobloxGui.Modules.Settings.Pages.Home)
-			this.HomePage:SetHub(this)
-		end
-	end
-
 	this.GameSettingsPage = require(RobloxGui.Modules.Settings.Pages.GameSettings)
 	this.GameSettingsPage:SetHub(this)
 
@@ -1159,22 +1150,17 @@ local function CreateSettingsHub()
 		this.RecordPage:SetHub(this)
 	end
 
-	if useUserList and not isTenFootInterface then
+	if not isTenFootInterface then
 		this.PlayersPage = require(RobloxGui.Modules.Settings.Pages.Players)
 		this.PlayersPage:SetHub(this)
 	end
 
 	-- page registration
-	if useUserList and not isTenFootInterface then
+	if not isTenFootInterface then
 		this:AddPage(this.PlayersPage)
 	end
 	this:AddPage(this.ResetCharacterPage)
 	this:AddPage(this.LeaveGamePage)
-	if not useUserList then
-		if this.HomePage then
-			this:AddPage(this.HomePage)
-		end
-	end
 	this:AddPage(this.GameSettingsPage)
 	if this.ReportAbusePage then
 		this:AddPage(this.ReportAbusePage)
@@ -1184,7 +1170,7 @@ local function CreateSettingsHub()
 		this:AddPage(this.RecordPage)
 	end
 
-	if useUserList and not isTenFootInterface then
+	if not isTenFootInterface then
 		this:SwitchToPage(this.PlayerPage, true, 1)
 	else
 		if this.HomePage then

--- a/CoreScriptsRoot/Modules/TenFootInterface.lua
+++ b/CoreScriptsRoot/Modules/TenFootInterface.lua
@@ -31,9 +31,6 @@ if FORCE_TEN_FOOT_INTERFACE then
 	tenFootInterfaceEnabled = true
 end
 
-local showVisibleAgeV2Success, showVisibleAgeV2Value = pcall(function() return settings():GetFFlag("CoreScriptShowVisibleAgeV2") end)
-local showVisibleAgeV2Enabled = showVisibleAgeV2Success and showVisibleAgeV2Value
-
 local Util = {}
 do
 	function Util.Create(instanceType)
@@ -65,7 +62,7 @@ local function CreateModule()
 			{
 				Name = "TopRightContainer";
 				Size = UDim2.new(0, 350, 0, 100);
-				Position = showVisibleAgeV2Enabled and UDim2.new(1,-415,0,10) or UDim2.new(1,-360,0,10);
+				Position = UDim2.new(1,-415,0,10);
 				AutoButtonColor = false;
 				Image = "";
 				Active = false;
@@ -206,7 +203,7 @@ local function CreateModule()
 		return this.Container, username, this.HealthContainer, healthFill, accountType
 	end
 
-	function this:CreateAccountTypeV2(accountTypeTextShort)
+	function this:CreateAccountType(accountTypeTextShort)
 		this.AccountTypeContainer = Util.Create'Frame'{
 			Name = "AccountTypeContainer";
 			Size = UDim2.new(0, 50, 0, 50);
@@ -232,68 +229,6 @@ local function CreateModule()
 			TextXAlignment = Enum.TextXAlignment.Center;
 			TextYAlignment = Enum.TextYAlignment.Center;
 		};
-	end
-
-	function this:CreateAccountType(accountTypeText)
-		local container = Util.Create'ImageButton'
-		{
-			Name = "AccountTypeContainer";
-			Position = UDim2.new(1,-370,0,10);
-			AutoButtonColor = false;
-			Image = "";
-			BackgroundTransparency = 1;
-			Parent = RobloxGui;
-		}
-
-		local bubble = Util.Create'ImageButton'
-		{
-			Name = "AccountTypeBubble";
-			Size = UDim2.new(1, -10, 1, -16);
-			Position = UDim2.new(0, 10, 0, 8);
-			AutoButtonColor = false;
-			Image = "rbxasset://textures/ui/TopBar/Round.png";
-			ScaleType = Enum.ScaleType.Slice;
-			SliceCenter = Rect.new(10, 10, 10, 10);
-			ImageTransparency = 0;
-			BackgroundTransparency = 1;
-			Parent = container;
-		}
-
-		local accountTypeTextLabel = Util.Create'TextLabel'{
-			Name = "AccountTypeText";
-			Text = accountTypeText;
-			Size = UDim2.new(1, -12, 1, -12);
-			Position = UDim2.new(0, 6, 0, 6);
-			Font = Enum.Font.SourceSansBold;
-			FontSize = Enum.FontSize.Size14;
-			BackgroundTransparency = 1;
-			TextColor3 = Color3.new(1,1,1);
-			TextYAlignment = Enum.TextYAlignment.Center;
-			TextXAlignment = Enum.TextXAlignment.Left;
-			Parent = bubble;
-		};
-
-		local function repositionAccountType()
-			local negativeYOffset = 375
-			if #displayStack == 0 then
-				negativeYOffset = 15
-			elseif #displayStack == 1 and displayStack[1] == this.HealthContainer then
-				if this.HealthContainer.Visible == false then
-					negativeYOffset = 10
-				end
-			end
-
-			local containerSize = 22 + accountTypeTextLabel.TextBounds.X
-			container.Size = UDim2.new(0, containerSize, 0, 50)
-			container.Position = UDim2.new(1,- (negativeYOffset + containerSize),0,10);
-		end
-
-		repositionAccountType()
-
-		displayStackChanged.Event:connect(repositionAccountType)
-		healthContainerPropertyChanged.Event:connect(repositionAccountType)
-
-		return nil
 	end
 
 	function this:SetupTopStat()
@@ -443,10 +378,6 @@ local moduleApiTable = {}
 
 	function moduleApiTable:CreateAccountType(accountTypeText)
 		return TenFootInterfaceModule:CreateAccountType(accountTypeText)
-	end
-
-	function moduleApiTable:CreateAccountTypeV2(accountTypeTextShort)
-		return TenFootInterfaceModule:CreateAccountTypeV2(accountTypeTextShort)
 	end
 
 	function moduleApiTable:SetupTopStat()


### PR DESCRIPTION
Remove the following 15 fast flags:
FFlagCorescriptNewChatSetCoresEnabled
FFlagCorescriptSetCoreChatActiveEnabled
FFlagLoadDefaultChatEnabled
FFlagCorescriptGetCorePlayerEvents
FFlagEnableSetCoreTopbarEnabled
FFlagOnlyShowHealthWhenDamaged
FFlagUserChatPrivacySetting
FFlagUseUserListMenu
FFlagCoreScriptShowVisibleAge
FFlagCoreScriptShowVisibleAgeXbox
FFlagCoreScriptShowVisibleAgeV2
DFFlagSetCoreDisableNotifications
DFFlagSetCoreSendNotifications
DFFlagSetCoreMoveChat
DFFlagSetCoreDisableChatBar