### PR TITLE
CLIAVATAR-33: Fix shift lock allowing players to see through walls

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript.rbxmx
@@ -142,7 +142,7 @@ local function Update()
 	end
 
 	if EnabledOcclusion then
-		EnabledOcclusion:Update()
+		EnabledOcclusion:Update(EnabledCamera)
 	end
 	
 	if shouldUsePlayerScriptsCamera() then

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/PopperCam.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/PopperCam.rbxmx
@@ -15,6 +15,7 @@ local PopperCam = {} -- Guarantees your players won't see outside the bounds of 
 -----------------
 
 local POP_RESTORE_RATE = 0.3
+local MIN_CAMERA_ZOOM = 0.5
 
 local VALID_SUBJECTS = {
 	'Humanoid',
@@ -44,6 +45,8 @@ local VehicleParts = {} -- Also just for ignoring
 local LastPopAmount = 0
 local LastZoomLevel = 0
 local PopperEnabled = false
+
+local CFrame_new = CFrame.new
 
 -----------------------
 --| Local Functions |--
@@ -124,7 +127,7 @@ end
 --| Exposed Functions |--
 -------------------------
 
-function PopperCam:Update()
+function PopperCam:Update(EnabledCamera)
 	if PopperEnabled then
 		-- First, prep some intermediate vars
 		local cameraCFrame = Camera.CFrame
@@ -150,12 +153,12 @@ function PopperCam:Update()
 		local zoomLevel = (cameraCFrame.p - focusPoint).Magnitude
 		if math_abs(zoomLevel - LastZoomLevel) > 0.001 then
 			LastPopAmount = 0
-		end		
+		end
 		
 		-- Finally, zoom the camera in (pop) by that most-cut-off amount, or the last pop amount if that's more
 		local popAmount = largest
 		if LastPopAmount > popAmount then
-			popAmount = LastPopAmount	
+			popAmount = LastPopAmount
 		end
 
 		if popAmount > 0 then
@@ -167,6 +170,17 @@ function PopperCam:Update()
 		end
 
 		LastZoomLevel = zoomLevel
+		
+		-- Stop shift lock being able to see through walls by manipulating Camera focus inside the wall
+		if EnabledCamera and EnabledCamera:GetShiftLock() and not EnabledCamera:IsInFirstPerson() then
+			if EnabledCamera:GetCameraActualZoom() < 1 then
+				local subjectPosition = EnabledCamera.lastSubjectPosition 
+				if subjectPosition then
+					Camera.Focus = CFrame_new(subjectPosition)
+					Camera.CFrame = CFrame_new(subjectPosition - MIN_CAMERA_ZOOM*EnabledCamera:GetCameraLook(), subjectPosition)
+				end
+			end
+		end
 	end
 end
 


### PR DESCRIPTION
This change goes along with a change to the implementation of
Camera:GetLargestCutoffDistance() which returns a maximum cutoff
distance if the camera focus is inside another part. If the focus moves
in another part this change pops the camera in fully and moves the focus
to the subject position rather than the shift lock offset position.