### PR TITLE
ScriptSignal update

### DIFF
--- a/CoreScriptsRoot/Libraries/RbxUtility.lua
+++ b/CoreScriptsRoot/Libraries/RbxUtility.lua
@@ -787,30 +787,40 @@ function t.CreateSignal()
 		if type(func) ~= 'function' then
 			error("Argument #1 of connect must be a function, got a "..type(func), 2)
 		end
-		local cn = mBindableEvent.Event:connect(func)
+		local cn = mBindableEvent.Event:Connect(func)
 		mAllCns[cn] = true
 		local pubCn = {}
 		function pubCn:disconnect()
-			cn:disconnect()
+			cn:Disconnect()
 			mAllCns[cn] = nil
 		end
+		pubCn.Disconnect = pubCn.disconnect
+		
 		return pubCn
 	end
+	
 	function this:disconnect()
 		if self ~= this then error("disconnect must be called with `:`, not `.`", 2) end
 		for cn, _ in pairs(mAllCns) do
-			cn:disconnect()
+			cn:Disconnect()
 			mAllCns[cn] = nil
 		end
 	end
+	
 	function this:wait()
 		if self ~= this then error("wait must be called with `:`, not `.`", 2) end
-		return mBindableEvent.Event:wait()
+		return mBindableEvent.Event:Wait()
 	end
+	
 	function this:fire(...)
 		if self ~= this then error("fire must be called with `:`, not `.`", 2) end
 		mBindableEvent:Fire(...)
 	end
+	
+	this.Connect = this.connect
+	this.Disconnect = this.disconnect
+	this.Wait = this.wait
+	this.Fire = this.fire
 
 	return this
 end


### PR DESCRIPTION
No longer using deprecated methods: connect, disconnect, and wait.
Creates aliases for the Signal class with PascalCase names to retain consistency across the rest of the Roblox API.