### PR TITLE
CLIPLAYEREX-120 Size of dynamic thumbstick area in landscape mode

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
@@ -102,34 +102,18 @@ local hasGameLoaded = false
 local GestureArea = nil
 
 do
-	-- Check for changes in ViewportSize to decide if PortraitMode
-	local CameraChangedConn = nil
-	local function onWorkspaceChanged(property)
-		if property == 'CurrentCamera' then
-			if CameraChangedConn then
-				CameraChangedConn:Disconnect()
-				CameraChangedConn = nil
-			end
-			local newCamera = workspace.CurrentCamera
-			if newCamera then
-				local size = newCamera.ViewportSize
-				PortraitMode = size.X < size.Y
-				DefaultZoom = PortraitMode and PORTRAIT_DEFAULT_ZOOM or LANDSCAPE_DEFAULT_ZOOM
-				CameraChangedConn = newCamera.Changed:Connect(function(property)
-					if property == 'ViewportSize' then
-						size = newCamera.ViewportSize
-						PortraitMode = size.X < size.Y
-						DefaultZoom = PortraitMode and PORTRAIT_DEFAULT_ZOOM or LANDSCAPE_DEFAULT_ZOOM
-					end
-				end)
+	local function layoutGestureArea(portraitMode)
+		if GestureArea then
+			if portraitMode then
+				GestureArea.Size = UDim2.new(1, 0, .6, 0)
+				GestureArea.Position = UDim2.new(0, 0, 0, 0)
+			else
+				GestureArea.Size = UDim2.new(1, 0, .5, -18)
+				GestureArea.Position = UDim2.new(0, 0, 0, 0)
 			end
 		end
 	end
-	workspace.Changed:Connect(onWorkspaceChanged)
-	if workspace.CurrentCamera then
-		onWorkspaceChanged('CurrentCamera')
-	end
-
+	
 	-- Setup gesture area that camera uses while DynamicThumbstick is enabled
 	local function OnCharacterAdded(character)
 		if PlayerGui then
@@ -140,9 +124,9 @@ do
 			GestureArea.BackgroundTransparency = 1.0
 			GestureArea.Visible = true
 			GestureArea.BackgroundColor3 = Color3.fromRGB(0, 0, 0)
-			GestureArea.Size = UDim2.new(1, 0, .6, 0)
-			GestureArea.Position = UDim2.new(0, 0, 0, 0)
 			GestureArea.Parent = ScreenGui
+			layoutGestureArea(PortraitMode)
+			
 		end
 		for _, child in ipairs(LocalPlayer.Character:GetChildren()) do
 			if child:IsA("Tool") then
@@ -168,6 +152,36 @@ do
 		LocalPlayer.CharacterAdded:connect(function(character)
 			OnCharacterAdded(character)
 		end)
+	end
+	
+	-- Check for changes in ViewportSize to decide if PortraitMode
+	local CameraChangedConn = nil
+	local function onWorkspaceChanged(property)
+		if property == 'CurrentCamera' then
+			if CameraChangedConn then
+				CameraChangedConn:Disconnect()
+				CameraChangedConn = nil
+			end
+			local newCamera = workspace.CurrentCamera
+			if newCamera then
+				local size = newCamera.ViewportSize
+				PortraitMode = size.X < size.Y
+				layoutGestureArea(PortraitMode)
+				DefaultZoom = PortraitMode and PORTRAIT_DEFAULT_ZOOM or LANDSCAPE_DEFAULT_ZOOM
+				CameraChangedConn = newCamera.Changed:Connect(function(property)
+					if property == 'ViewportSize' then
+						size = newCamera.ViewportSize
+						PortraitMode = size.X < size.Y
+						layoutGestureArea(PortraitMode)
+						DefaultZoom = PortraitMode and PORTRAIT_DEFAULT_ZOOM or LANDSCAPE_DEFAULT_ZOOM
+					end
+				end)
+			end
+		end
+	end
+	workspace.Changed:Connect(onWorkspaceChanged)
+	if workspace.CurrentCamera then
+		onWorkspaceChanged('CurrentCamera')
 	end
 end
 	

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
@@ -116,33 +116,35 @@ do
 	
 	-- Setup gesture area that camera uses while DynamicThumbstick is enabled
 	local function OnCharacterAdded(character)
-		if PlayerGui then
-			local ScreenGui = Instance.new("ScreenGui")
-			ScreenGui.Parent = PlayerGui
-			
-			GestureArea = Instance.new("Frame")
-			GestureArea.BackgroundTransparency = 1.0
-			GestureArea.Visible = true
-			GestureArea.BackgroundColor3 = Color3.fromRGB(0, 0, 0)
-			GestureArea.Parent = ScreenGui
-			layoutGestureArea(PortraitMode)
-			
+		if UserInputService.TouchEnabled then
+			if PlayerGui then
+				local ScreenGui = Instance.new("ScreenGui")
+				ScreenGui.Parent = PlayerGui
+				
+				GestureArea = Instance.new("Frame")
+				GestureArea.BackgroundTransparency = 1.0
+				GestureArea.Visible = true
+				GestureArea.BackgroundColor3 = Color3.fromRGB(0, 0, 0)
+				layoutGestureArea(PortraitMode)
+				GestureArea.Parent = ScreenGui
+				
+			end
+			for _, child in ipairs(LocalPlayer.Character:GetChildren()) do
+				if child:IsA("Tool") then
+					IsAToolEquipped = true
+				end
+			end
+			character.ChildAdded:Connect(function(child)
+				if child:IsA("Tool") then
+					IsAToolEquipped = true
+				end
+			end)
+			character.ChildRemoved:Connect(function(child)
+				if child:IsA("Tool") then
+					IsAToolEquipped = false
+				end
+			end)
 		end
-		for _, child in ipairs(LocalPlayer.Character:GetChildren()) do
-			if child:IsA("Tool") then
-				IsAToolEquipped = true
-			end
-		end
-		character.ChildAdded:Connect(function(child)
-			if child:IsA("Tool") then
-				IsAToolEquipped = true
-			end
-		end)
-		character.ChildRemoved:Connect(function(child)
-			if child:IsA("Tool") then
-				IsAToolEquipped = false
-			end
-		end)
 	end
 	
 	if LocalPlayer then
@@ -157,7 +159,7 @@ do
 	-- Check for changes in ViewportSize to decide if PortraitMode
 	local CameraChangedConn = nil
 	local function onWorkspaceChanged(property)
-		if property == 'CurrentCamera' then
+		if property == 'CurrentCamera' and UserInputService.TouchEnabled then
 			if CameraChangedConn then
 				CameraChangedConn:Disconnect()
 				CameraChangedConn = nil

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DynamicThumbstick.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DynamicThumbstick.rbxmx
@@ -176,9 +176,8 @@ function Thumbstick:Create(parentFrame)
 	ThumbstickFrame.Visible = false
 	ThumbstickFrame.BackgroundTransparency = 1.0
 	ThumbstickFrame.BackgroundColor3 = Color3.fromRGB(0, 0, 0)
-	layoutThumbstickFrame()	
-	--ThumbstickFrame.Size = UDim2.new(1, 0, .5, 18)
-	--ThumbstickFrame.Position = UDim2.new(0, 0, 0.5, -18)
+	layoutThumbstickFrame()
+	
 	local CameraChangedConn = nil
 	local function onWorkspaceChanged(property)
 		if property == 'CurrentCamera' then
@@ -213,9 +212,9 @@ function Thumbstick:Create(parentFrame)
 	ImageCenter.BackgroundTransparency = 1
 	ImageCenter.Size = UDim2.new(0, ThumbstickSize, 0, ThumbstickSize)
 	ImageCenter.Position = UDim2.new(0, screenSize.x/2, 0, screenSize.y/2)
-	ImageCenter.Parent = ThumbstickFrame
 	ImageCenter.Visible = false
 	ImageCenter.ImageTransparency = 0
+	ImageCenter.Parent = ThumbstickFrame
 	
 	ImageRod = Instance.new("ImageLabel")
 	ImageRod.Name = "ImageRod"
@@ -224,9 +223,9 @@ function Thumbstick:Create(parentFrame)
 	ImageRod.BackgroundTransparency = 1
 	ImageRod.Size = UDim2.new(0, ImageRodMinSize, 0, ImageRodMinSize)
 	ImageRod.Position = UDim2.new(0, screenSize.x/2, 0, screenSize.y/2)
-	ImageRod.Parent = ThumbstickFrame
 	ImageRod.Visible = false
-	ImageRod.ImageTransparency = 0.7	
+	ImageRod.ImageTransparency = 0.7
+	ImageRod.Parent = ThumbstickFrame	
 	
 	ImageUnderThumb = Instance.new('ImageLabel')
 	ImageUnderThumb.Name = "ImageUnderThumb"
@@ -236,10 +235,9 @@ function Thumbstick:Create(parentFrame)
 	ImageUnderThumb.Size = UDim2.new(0, ThumbstickSize, 0, ThumbstickSize)
 	ImageUnderThumb.Position = UDim2.new(0, 20, 0, 20)
 	ImageUnderThumb.ZIndex = 2
-	ImageUnderThumb.Parent = ThumbstickFrame
 	ImageUnderThumb.Visible = false
 	ImageUnderThumb.ImageTransparency = 0
-	
+	ImageUnderThumb.Parent = ThumbstickFrame
 	
 	local JumpTouchObject = nil
 	local JumpTouchStartTime = nil

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DynamicThumbstick.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DynamicThumbstick.rbxmx
@@ -159,15 +159,52 @@ function Thumbstick:Create(parentFrame)
 	end
 	
 	local color = Color3.fromRGB(255, 255, 255)
+	
+	local function layoutThumbstickFrame(portraitMode)
+		if portraitMode then
+			ThumbstickFrame.Size = UDim2.new(1, 0, .4, 0)
+			ThumbstickFrame.Position = UDim2.new(0, 0, 0.6, 0)
+		else
+			ThumbstickFrame.Size = UDim2.new(1, 0, .5, 18)
+			ThumbstickFrame.Position = UDim2.new(0, 0, 0.5, -18)
+		end
+	end
 		
 	ThumbstickFrame = Instance.new('Frame')
 	ThumbstickFrame.Name = "ThumbstickFrame"
 	ThumbstickFrame.Active = false
 	ThumbstickFrame.Visible = false
 	ThumbstickFrame.BackgroundTransparency = 1.0
-	ThumbstickFrame.BackgroundColor3 = color
-	ThumbstickFrame.Size = UDim2.new(1, 0, .4, 0)
-	ThumbstickFrame.Position = UDim2.new(0, 0, 0.6, 0)
+	ThumbstickFrame.BackgroundColor3 = Color3.fromRGB(0, 0, 0)
+	layoutThumbstickFrame()	
+	--ThumbstickFrame.Size = UDim2.new(1, 0, .5, 18)
+	--ThumbstickFrame.Position = UDim2.new(0, 0, 0.5, -18)
+	local CameraChangedConn = nil
+	local function onWorkspaceChanged(property)
+		if property == 'CurrentCamera' then
+			if CameraChangedConn then
+				CameraChangedConn:Disconnect()
+				CameraChangedConn = nil
+			end
+			local newCamera = workspace.CurrentCamera
+			if newCamera then
+				local size = newCamera.ViewportSize
+				local portraitMode = size.X < size.Y
+				layoutThumbstickFrame(portraitMode)
+				CameraChangedConn = newCamera.Changed:Connect(function(property)
+					if property == 'ViewportSize' then
+						size = newCamera.ViewportSize
+						portraitMode = size.X < size.Y
+						layoutThumbstickFrame(portraitMode)
+					end
+				end)
+			end
+		end
+	end
+	workspace.Changed:Connect(onWorkspaceChanged)
+	if workspace.CurrentCamera then
+		onWorkspaceChanged('CurrentCamera')
+	end
 	
 	ImageCenter = Instance.new('ImageLabel')
 	ImageCenter.Name = "ImageCenter"


### PR DESCRIPTION
The gesture area for thumbstick and camera is now a different proportion of the screen in landscape vs. portrait mode. (The thumbstick take up 2/5 of the screen in portrait mode and 1/2 in landscape mode.)