### PR TITLE
Fix issues with ChatVisible game setting.

### DIFF
--- a/CoreScriptsRoot/CoreScripts/Topbar.lua
+++ b/CoreScriptsRoot/CoreScripts/Topbar.lua
@@ -88,6 +88,11 @@ do
 		return InputService.TouchEnabled
 	end
 
+	function Util.IsSmallTouchScreen()
+		local screenResolution = GuiService:GetScreenResolution()
+		return InputService.TouchEnabled and (screenResolution.Y < 500 or screenResolution.X < 700)
+	end
+
 	function Util.Create(instanceType)
 		return function(data)
 			local obj = Instance.new(instanceType)
@@ -873,7 +878,7 @@ local function CreateLeaderstatsMenuItem()
 	rawset(this, "SetColumns",
 		function(self, columnsList)
 			-- Should we handle is the screen dimensions change and it is no longer a small touch device after we set columns?
-			local isSmallTouchDevice = Util.IsTouchDevice() and GuiService:GetScreenResolution().Y < 500
+			local isSmallTouchDevice = Util.IsSmallTouchScreen()
 			local numColumns = #columnsList
 
 			-- Destroy old columns
@@ -1257,7 +1262,7 @@ local function CreateChatIcon()
 		if newChatVisibleProp then
 			willEnableChat = GameSettings.ChatVisible
 		end
-		if Util.IsTouchDevice() and GuiService:GetScreenResolution().Y < 700 then
+		if Util.IsSmallTouchScreen() then
 			willEnableChat = false
 		end
 		ChatModule:SetVisible(willEnableChat)

--- a/CoreScriptsRoot/CoreScripts/Topbar.lua
+++ b/CoreScriptsRoot/CoreScripts/Topbar.lua
@@ -1254,11 +1254,11 @@ local function CreateChatIcon()
 	if not InputService.VREnabled then
 		-- check to see if the chat was disabled
 		local willEnableChat = true
-		if Util.IsTouchDevice() and GuiService:GetScreenResolution().Y < 700 then
-			willEnableChat = false
-		end
 		if newChatVisibleProp then
 			willEnableChat = GameSettings.ChatVisible
+		end
+		if Util.IsTouchDevice() and GuiService:GetScreenResolution().Y < 700 then
+			willEnableChat = false
 		end
 		ChatModule:SetVisible(willEnableChat)
 	end
@@ -1317,13 +1317,13 @@ local function CreateMobileHideChatIcon()
 
 	local function onChatStateChanged(visible)
 		updateIcon(visible)
-		if newChatVisibleProp then
-			GameSettings.ChatVisible = visible
-		end
 	end
 
 	chatHideIconButton.MouseButton1Click:connect(function()
 		toggleChat()
+		if newChatVisibleProp then
+			GameSettings.ChatVisible = ChatModule:GetVisibility()
+		end
 	end)
 
 	if ChatModule.VisibilityStateChanged then


### PR DESCRIPTION
- Fix developers toggling GameSettings.ChatVisible
- Fix GameSettings.ChatVisible taking prefernce over being closed on
small screened mobile devices. We always want to start closed on these
devices.