### PR TITLE
Move LoadDefaultChat check to ServerStarterScript

### DIFF
--- a/CoreScriptsRoot/Modules/Server/ClientChat/ChatWindowInstaller.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/ChatWindowInstaller.lua
@@ -2,7 +2,6 @@ local runnerScriptName = "ChatScript"
 local bubbleChatScriptName = "BubbleChat"
 local installDirectory = game:GetService("Chat")
 
-local ChatService = game:GetService("Chat")
 local PlayersService = game:GetService("Players")
 local StarterPlayerScripts = game:GetService("StarterPlayer"):WaitForChild("StarterPlayerScripts")
 
@@ -35,10 +34,6 @@ local function GetBoolValue(parent, name, defaultValue)
 end
 
 local function Install()
-	if not ChatService.LoadDefaultChat then
-		return
-	end
-
 	local chatScriptArchivable = true
 	local ChatScript = installDirectory:FindFirstChild(runnerScriptName)
 	if not ChatScript then

--- a/CoreScriptsRoot/Modules/Server/ServerChat/ChatServiceInstaller.lua
+++ b/CoreScriptsRoot/Modules/Server/ServerChat/ChatServiceInstaller.lua
@@ -1,6 +1,5 @@
 local runnerScriptName = "ChatServiceRunner"
 
-local ChatService = game:GetService("Chat")
 local installDirectory = game:GetService("Chat")
 local ServerScriptService = game:GetService("ServerScriptService")
 
@@ -34,10 +33,6 @@ end
 
 
 local function Install()
-	if not ChatService.LoadDefaultChat then
-		return
-	end
-
 	local chatServiceRunnerArchivable = true
 	local ChatServiceRunner = installDirectory:FindFirstChild(runnerScriptName)
 	if not ChatServiceRunner then

--- a/CoreScriptsRoot/ServerStarterScript.lua
+++ b/CoreScriptsRoot/ServerStarterScript.lua
@@ -83,6 +83,7 @@ game:GetService("Players").PlayerRemoving:connect(function(player)
 	end
 end)
 
-
-require(game:GetService("CoreGui").RobloxGui.Modules.Server.ClientChat.ChatWindowInstaller)()
-require(game:GetService("CoreGui").RobloxGui.Modules.Server.ServerChat.ChatServiceInstaller)()
+if game:GetService("Chat").LoadDefaultChat then
+	require(game:GetService("CoreGui").RobloxGui.Modules.Server.ClientChat.ChatWindowInstaller)()
+	require(game:GetService("CoreGui").RobloxGui.Modules.Server.ServerChat.ChatServiceInstaller)()
+end


### PR DESCRIPTION
When LoadDefaultChat is false, the ChatServiceInstaller and ChatWindowInstaller modules are not required at all, which reduces the chance of unintended side-effects.