### PR TITLE
Add corescript code for removing recording popup

### DIFF
--- a/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/NotificationScript2.lua
@@ -40,6 +40,9 @@ local disableScreenshotPopup = getDisableScreenshotPopup and disableScreenshotPo
 local useNewThumbnailApiSuccess, useNewThumbnailApiValue = pcall(function() return settings():GetFFlag("CoreScriptsUseNewUserThumbnailAPI") end)
 local useNewUserThumbnailAPI = useNewThumbnailApiSuccess and useNewThumbnailApiValue
 
+local getDisableVideoRecordPopup, disableVideoRecordPopupValue = pcall(function() return settings():GetFFlag("DisableVideoRecordPopup") end)
+local disableVideoRecordPopup = getDisableVideoRecordPopup and disableVideoRecordPopupValue
+
 --[[ Script Variables ]]--
 local LocalPlayer = nil
 while not Players.LocalPlayer do
@@ -748,6 +751,24 @@ if disableScreenshotPopup then
 				end
 			end
 		}
+	end)
+end
+
+if disableVideoRecordPopup then
+	settings():GetService("GameSettings").VideoRecordingChangeRequest:Connect(function(value)
+		if not value then
+			sendNotificationInfo {
+				Title = "Video Recorded",
+				Text = "Check out your videos folder to see it.",
+				Duration = 3.0,
+				Button1Text = "Open Folder",
+				Callback = function(text)
+					if text == "Open Folder" then
+						game:OpenVideosFolder()
+					end
+				end
+			}
+		end
 	end)
 end
 

--- a/CoreScriptsRoot/Modules/Settings/Pages/Record.lua
+++ b/CoreScriptsRoot/Modules/Settings/Pages/Record.lua
@@ -20,6 +20,9 @@ local isTenFootInterface = require(RobloxGui.Modules.TenFootInterface):IsEnabled
 local enablePortraitModeSuccess, enablePortraitModeValue = pcall(function() return settings():GetFFlag("EnablePortraitMode") end)
 local enablePortraitMode = enablePortraitModeSuccess and enablePortraitModeValue
 
+local getDisableVideoRecordPopup, disableVideoRecordPopupValue = pcall(function() return settings():GetFFlag("DisableVideoRecordPopup") end)
+local disableVideoRecordPopup = getDisableVideoRecordPopup and disableVideoRecordPopupValue
+
 ------------ Variables -------------------
 local PageInstance = nil
 
@@ -170,18 +173,20 @@ local function Initialize()
  			videoBody = makeTextLabelOld("VideoBody", "By clicking the 'Record Video' button, the menu will close and start recording your screen.", false, UDim2.new(1,-10,0,70), UDim2.new(0,0,1,0), videoTitle)
 		end
 
-		this.VideoSettingsFrame, 
-		this.VideoSettingsLabel,
-		this.VideoSettingsMode = utility:AddNewRow(this, "Video Settings", "Selector", recordEnumNames, startSetting, enablePortraitMode and nil or 270)
-		this.VideoSettingsFrame.LayoutOrder = 5
+		if not disableVideoRecordPopup then
+			this.VideoSettingsFrame, 
+			this.VideoSettingsLabel,
+			this.VideoSettingsMode = utility:AddNewRow(this, "Video Settings", "Selector", recordEnumNames, startSetting, enablePortraitMode and nil or 270)
+			this.VideoSettingsFrame.LayoutOrder = 5
 
-		this.VideoSettingsMode.IndexChanged:connect(function(newIndex)
-			if newIndex == 1 then
-				GameSettings.VideoUploadPromptBehavior = Enum.UploadSetting.Never
-			elseif newIndex == 2 then
-				GameSettings.VideoUploadPromptBehavior = Enum.UploadSetting.Always
-			end
-		end)
+			this.VideoSettingsMode.IndexChanged:connect(function(newIndex)
+				if newIndex == 1 then
+					GameSettings.VideoUploadPromptBehavior = Enum.UploadSetting.Never
+				elseif newIndex == 2 then
+					GameSettings.VideoUploadPromptBehavior = Enum.UploadSetting.Always
+				end
+			end)
+		end
 		
 		local recordButtonRow, recordButton
 		if enablePortraitMode then
@@ -193,8 +198,13 @@ local function Initialize()
 		else
 			recordButton = utility:MakeStyledButton("RecordButton", "Record Video", UDim2.new(0,300,0,44), closeSettingsFunc, this)
 	  		
-	 		recordButton.Position = UDim2.new(0,410,1,10)
-	 		recordButton.Parent = this.VideoSettingsMode.SelectorFrame.Parent
+			if not disableVideoRecordPopup then
+				recordButton.Position = UDim2.new(0,410,1,10)
+				recordButton.Parent = this.VideoSettingsMode.SelectorFrame.Parent
+			else
+				recordButton.Position = UDim2.new(0,400,1,0)
+	 			recordButton.Parent = videoBody
+			end
 	 	end
 
 		local gameOptions = settings():FindFirstChild("Game Options")


### PR DESCRIPTION
Adds a notification when a video has finished being recorded, which is just like the one for screenshots.
Removes the selector for whether to upload to youtube or not.
Code is flagged so that it will only turn on in sync with the client code that removes the old IE ActiveX popup.