### PR TITLE
Use GetPropertyChangedSignal for Camera.Changed listeners

### DIFF
--- a/CoreScriptsRoot/Modules/LoadingScreen3D.lua
+++ b/CoreScriptsRoot/Modules/LoadingScreen3D.lua
@@ -327,10 +327,8 @@ do
 			if CameraChangedConn then
 				CameraChangedConn:disconnect()
 			end
-			CameraChangedConn = workspace.CurrentCamera.Changed:connect(function(prop)
-				if prop == 'CFrame' then
-					UpdateSurfaceGuiPosition()
-				end
+			CameraChangedConn = workspace.CurrentCamera:GetPropertyChangedSignal("CFrame"):connect(function()
+				UpdateSurfaceGuiPosition()
 			end)
 		end
 	end

--- a/CoreScriptsRoot/Modules/Server/ClientChat/BubbleChat/BubbleChat.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/BubbleChat/BubbleChat.lua
@@ -602,13 +602,6 @@ function this:ShowOwnFilteredMessage()
 	return false
 end
 
-function this:CameraChanged(prop)
-	if prop == "CoordinateFrame" then
-		this:CameraCFrameChanged()
-	end
-end
-
-
 function findPlayer(playerName)
 	for i,v in pairs(PlayersService:GetPlayers()) do
 		if v.Name == playerName then
@@ -621,14 +614,14 @@ ChatService.Chatted:connect(function(origin, message, color) this:OnGameChatMess
 
 local cameraChangedCon = nil
 if game.Workspace.CurrentCamera then
-	cameraChangedCon = game.Workspace.CurrentCamera.Changed:connect(function(prop) this:CameraChanged(prop) end)
+	cameraChangedCon = game.Workspace.CurrentCamera:GetPropertyChangedSignal("CFrame"):connect(function(prop) this:CameraCFrameChanged() end)
 end
 
 game.Workspace.Changed:connect(function(prop)
 	if prop == "CurrentCamera" then
 		if cameraChangedCon then cameraChangedCon:disconnect() end
 		if game.Workspace.CurrentCamera then
-			cameraChangedCon = game.Workspace.CurrentCamera.Changed:connect(function(prop) this:CameraChanged(prop) end)
+			cameraChangedCon = game.Workspace.CurrentCamera:GetPropertyChangedSignal("CFrame"):connect(function(prop) this:CameraCFrameChanged() end)
 		end
 	end
 end)

--- a/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
+++ b/CoreScriptsRoot/Modules/Settings/SettingsHub.lua
@@ -518,14 +518,15 @@ local function CreateSettingsHub()
 		)
 
 		local function cameraViewportChanged(prop)
-			if prop == "ViewportSize" then
-				utility:FireOnResized()
-			end
+			utility:FireOnResized()
 		end
+
+		local viewportSizeChangedConn = nil
 		local function onWorkspaceChanged(prop)
 			if prop == "CurrentCamera" then
-				cameraViewportChanged("ViewportSize")
-				workspace.CurrentCamera.Changed:connect(cameraViewportChanged)
+				cameraViewportChanged()
+				if viewportSizeChangedConn then viewportSizeChangedConn:disconnect() end
+				viewportSizeChangedConn = workspace.CurrentCamera:GetPropertyChangedSignal("ViewportSize"):connect(cameraViewportChanged)
 			end
 		end
 		onWorkspaceChanged("CurrentCamera")

--- a/CoreScriptsRoot/Modules/VR/Panel3D.lua
+++ b/CoreScriptsRoot/Modules/VR/Panel3D.lua
@@ -1052,24 +1052,22 @@ RunService.Heartbeat:connect(onHeartbeat)
 
 
 local cameraChangedConnection = nil
-local function onCameraChanged(prop)
-	if prop == "HeadScale" then
-		pcall(function()
-			currentHeadScale = workspace.CurrentCamera.HeadScale
-		end)
-		for i, v in pairs(panels) do
-			v:OnHeadScaleChanged(currentHeadScale)
-		end
+local function onHeadScalePropChanged(prop)
+	pcall(function()
+		currentHeadScale = workspace.CurrentCamera.HeadScale
+	end)
+	for i, v in pairs(panels) do
+		v:OnHeadScaleChanged(currentHeadScale)
 	end
 end
 
 local function onWorkspaceChanged(prop)
 	if prop == "CurrentCamera" then
-		onCameraChanged("HeadScale")
+		onHeadScalePropChanged()
 		if cameraChangedConnection then
 			cameraChangedConnection:disconnect()
 		end
-		cameraChangedConnection = workspace.CurrentCamera.Changed:connect(onCameraChanged)
+		cameraChangedConnection = workspace.CurrentCamera:GetPropertyChangedSignal("HeadScale"):connect(onHeadScalePropChanged)
 
 		if UserInputService.VREnabled then
 			partFolder.Parent = workspace.CurrentCamera

--- a/CoreScriptsRoot/Modules/VR/Panel3D.lua
+++ b/CoreScriptsRoot/Modules/VR/Panel3D.lua
@@ -3,7 +3,7 @@
 --revised/refactored 5/11/16
 
 local UserInputService = game:GetService("UserInputService")
-local VRServiceExists, VRService = pcall(function() return game:GetService("VRService") end)
+local VRService = game:GetService("VRService")
 local RunService = game:GetService("RunService")
 local GuiService = game:GetService("GuiService")
 local CoreGui = game:GetService("CoreGui")
@@ -952,10 +952,7 @@ local function onRenderStep()
 	local userHeadCF = UserInputService:GetUserCFrame(Enum.UserCFrame.Head)
 	local lookRay = Ray.new(cameraRenderCF.p, cameraRenderCF.lookVector)
 
-	local inputUserCFrame = Enum.UserCFrame.Head
-	if VRServiceExists then
-		inputUserCFrame = VRService.GuiInputUserCFrame
-	end
+	local inputUserCFrame = VRService.GuiInputUserCFrame
 	local inputCF = cameraCF * UserInputService:GetUserCFrame(inputUserCFrame)
 	local pointerRay = Ray.new(inputCF.p, inputCF.lookVector)
 
@@ -1053,9 +1050,7 @@ RunService.Heartbeat:connect(onHeartbeat)
 
 local cameraChangedConnection = nil
 local function onHeadScalePropChanged(prop)
-	pcall(function()
-		currentHeadScale = workspace.CurrentCamera.HeadScale
-	end)
+	currentHeadScale = workspace.CurrentCamera.HeadScale
 	for i, v in pairs(panels) do
 		v:OnHeadScaleChanged(currentHeadScale)
 	end

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript.rbxmx
@@ -51,7 +51,8 @@ local CameraTypeEnumMap =
 local EnabledCamera = nil
 local EnabledOcclusion = nil
 
-local currentCameraConn = nil
+local cameraSubjectChangedConn = nil
+local cameraTypeChangedConn = nil
 local renderSteppedConn = nil
 
 local lastInputType = nil
@@ -219,17 +220,21 @@ local function OnNewCamera()
 
 	local currentCamera = workspace.CurrentCamera
 	if currentCamera then
-		if currentCameraConn then
-			currentCameraConn:disconnect()
+		if cameraSubjectChangedConn then
+			cameraSubjectChangedConn:disconnect()
 		end
 		
-		currentCameraConn = currentCamera.Changed:connect(function(prop)
-			if prop == 'CameraType' then
-				OnCameraMovementModeChange(getCurrentCameraMode())
-				OnCameraTypeChanged(currentCamera.CameraType)
-			elseif prop == 'CameraSubject' then
-				OnCameraSubjectChanged(currentCamera.CameraSubject)
-			end
+		if cameraTypeChangedConn then
+			cameraTypeChangedConn:disconnect()
+		end
+		
+		cameraSubjectChangedConn = currentCamera:GetPropertyChangedSignal("CameraSubject"):connect(function()
+			OnCameraSubjectChanged(currentCamera.CameraSubject)
+		end)
+		
+		cameraTypeChangedConn = currentCamera:GetPropertyChangedSignal("CameraType"):connect(function()
+			OnCameraMovementModeChange(getCurrentCameraMode())
+			OnCameraTypeChanged(currentCamera.CameraType)
 		end)
 
 		OnCameraSubjectChanged(currentCamera.CameraSubject)

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/PopperCam.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/PopperCam.rbxmx
@@ -35,7 +35,7 @@ local FFlagUserPortraitPopperFix = portraitPopperFixFlagExists and portraitPoppe
 local PlayersService = game:GetService('Players')
 
 local Camera = nil
-local CameraChangeConn = nil
+local CameraSubjectChangeConn = nil
 
 local SubjectPart = nil
 
@@ -54,34 +54,32 @@ local CFrame_new = CFrame.new
 
 local math_abs = math.abs
 
-local function OnCameraChanged(property)
-	if property == 'CameraSubject' then
-		VehicleParts = {}
+local function OnCameraSubjectChanged()
+	VehicleParts = {}
 
-		local newSubject = Camera.CameraSubject
-		if newSubject then
-			-- Determine if we should be popping at all
-			PopperEnabled = false
-			for _, subjectType in pairs(VALID_SUBJECTS) do
-				if newSubject:IsA(subjectType) then
-					PopperEnabled = true
-					break
-				end
+	local newSubject = Camera.CameraSubject
+	if newSubject then
+		-- Determine if we should be popping at all
+		PopperEnabled = false
+		for _, subjectType in pairs(VALID_SUBJECTS) do
+			if newSubject:IsA(subjectType) then
+				PopperEnabled = true
+				break
 			end
-			
-			-- Get all parts of the vehicle the player is controlling
-			if newSubject:IsA('VehicleSeat') then
-				VehicleParts = newSubject:GetConnectedParts(true)
-			end
-			
-			if FFlagUserPortraitPopperFix then
-				if newSubject:IsA("BasePart") then
-					SubjectPart = newSubject
-				elseif newSubject:IsA("Model") then
-					SubjectPart = newSubject.PrimaryPart
-				elseif newSubject:IsA("Humanoid") then
-					SubjectPart = newSubject.Torso
-				end
+		end
+		
+		-- Get all parts of the vehicle the player is controlling
+		if newSubject:IsA('VehicleSeat') then
+			VehicleParts = newSubject:GetConnectedParts(true)
+		end
+		
+		if FFlagUserPortraitPopperFix then
+			if newSubject:IsA("BasePart") then
+				SubjectPart = newSubject
+			elseif newSubject:IsA("Model") then
+				SubjectPart = newSubject.PrimaryPart
+			elseif newSubject:IsA("Humanoid") then
+				SubjectPart = newSubject.Torso
 			end
 		end
 	end
@@ -114,11 +112,11 @@ local function OnWorkspaceChanged(property)
 		if newCamera then
 			Camera = newCamera
 			
-			if CameraChangeConn then
-				CameraChangeConn:disconnect()
+			if CameraSubjectChangeConn then
+				CameraSubjectChangeConn:disconnect()
 			end
-			CameraChangeConn = Camera.Changed:connect(OnCameraChanged)
-			OnCameraChanged('CameraSubject')
+			CameraSubjectChangeConn = CameracurrentCamera:GetPropertyChangedSignal("CameraSubject"):connect(OnCameraSubjectChanged)
+			OnCameraSubjectChanged()
 		end
 	end
 end

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/CameraScript/RootCamera.rbxmx
@@ -171,13 +171,11 @@ do
 				PortraitMode = size.X < size.Y
 				layoutGestureArea(PortraitMode)
 				DefaultZoom = PortraitMode and PORTRAIT_DEFAULT_ZOOM or LANDSCAPE_DEFAULT_ZOOM
-				CameraChangedConn = newCamera.Changed:Connect(function(property)
-					if property == 'ViewportSize' then
-						size = newCamera.ViewportSize
-						PortraitMode = size.X < size.Y
-						layoutGestureArea(PortraitMode)
-						DefaultZoom = PortraitMode and PORTRAIT_DEFAULT_ZOOM or LANDSCAPE_DEFAULT_ZOOM
-					end
+				CameraChangedConn = newCamera:GetPropertyChangedSignal("ViewportSize"):Connect(function()
+					size = newCamera.ViewportSize
+					PortraitMode = size.X < size.Y
+					layoutGestureArea(PortraitMode)
+					DefaultZoom = PortraitMode and PORTRAIT_DEFAULT_ZOOM or LANDSCAPE_DEFAULT_ZOOM
 				end)
 			end
 		end
@@ -602,7 +600,7 @@ local function CreateCamera()
 	local trackingHumanoid = nil
 	local cameraFrozen = false
 	local subjectStateChangedConn = nil
-	local cameraChangedConn = nil
+	local cameraSubjectChangedConn = nil
 	local workspaceChangedConn = nil
 	local humanoidChildAddedConn = nil
 	local humanoidChildRemovedConn = nil
@@ -689,21 +687,15 @@ local function CreateCamera()
 		end
 	end
 
-	local function onCameraChanged(prop)
-		if prop == 'CameraSubject' then
-			onNewCameraSubject()
-		end
-	end
-
 	local function onCurrentCameraChanged()
-		if cameraChangedConn then
-			cameraChangedConn:disconnect()
-			cameraChangedConn = nil
+		if cameraSubjectChangedConn then
+			cameraSubjectChangedConn:disconnect()
+			cameraSubjectChangedConn = nil
 		end
 		local camera = workspace.CurrentCamera
 		if camera then
-			camera.Changed:connect(onCameraChanged)
-			onCameraChanged('CameraSubject')
+			cameraSubjectChangedConn = camera:GetPropertyChangedSignal("CameraSubject"):connect(onNewCameraSubject)
+			onNewCameraSubject()
 		end
 	end
 

--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DynamicThumbstick.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DynamicThumbstick.rbxmx
@@ -190,12 +190,10 @@ function Thumbstick:Create(parentFrame)
 				local size = newCamera.ViewportSize
 				local portraitMode = size.X < size.Y
 				layoutThumbstickFrame(portraitMode)
-				CameraChangedConn = newCamera.Changed:Connect(function(property)
-					if property == 'ViewportSize' then
-						size = newCamera.ViewportSize
-						portraitMode = size.X < size.Y
-						layoutThumbstickFrame(portraitMode)
-					end
+				CameraChangedConn = newCamera:GetPropertyChangedSignal("ViewportSize"):Connect(function()
+					size = newCamera.ViewportSize
+					portraitMode = size.X < size.Y
+					layoutThumbstickFrame(portraitMode)
 				end)
 			end
 		end


### PR DESCRIPTION
This reduces the amount of overhead when setting busy properties on
Camera such as CFrame in the CameraScripts.