### PR TITLE
CLIPLAYEREX-458 Dynamic Thumbstick graphic displays past control zone

### DIFF
--- a/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DynamicThumbstick.rbxmx
+++ b/PlayerScripts/PlayerScriptsPlace/StarterPlayer/StarterPlayerScripts/ControlScript/MasterControl/DynamicThumbstick.rbxmx
@@ -303,12 +303,6 @@ function Thumbstick:Create(parentFrame)
 		local angle = -math.atan2(relativePosition.X/length, relativePosition.Y/length) + math.pi/2
 		local sinAngle = math.sin(angle)
 		local cosAngle = math.cos(angle)
-		if angle < -0.2 or angle > math.pi + 0.2 then
-			local y = MoveTouchStartPosition.Y - ThumbstickFrame.AbsolutePosition.Y
-			local adjustedAngle = math.fmod(math.abs(angle), math.pi/2)
-			
-			length = math.min(length, y/math.sin(adjustedAngle))
-		end
 		
 		local imageStickX = MoveTouchStartPosition.X - ImageUnderThumb.AbsoluteSize.X*0.5 - ThumbstickFrame.AbsolutePosition.X
 		local imageStickY = MoveTouchStartPosition.Y - ImageUnderThumb.AbsoluteSize.Y*0.5 - ThumbstickFrame.AbsolutePosition.Y


### PR DESCRIPTION
The code removed was responsible for making the dynamic thumbstick not
display past the bottom half of the screen. This change will make it so
the graphic will now follow the touch input around no matter where it
is on the screen.