### PR TITLE
found a variable misspelling issue

### DIFF
--- a/CoreScriptsRoot/Modules/NewChat.lua
+++ b/CoreScriptsRoot/Modules/NewChat.lua
@@ -109,7 +109,7 @@ do
 
 		function moduleApiTable:IsFocused(useWasFocused)
 			local success, retVal = AttemptInvokeFunction("IsFocused", useWasFocused)
-			if (sucucess) then
+			if (success) then -- sucucess isn't defined.
 				return retVal
 			else
 				return false


### PR DESCRIPTION
variable misspelling that would've caused the else scenario to always fire.