### PR TITLE
Prevent redundant SetCore CoreGuiChatConnection attempt

### DIFF
--- a/CoreScriptsRoot/Modules/Server/ClientChat/ChatScript.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/ChatScript.lua
@@ -102,19 +102,17 @@ local function DoEverything()
 end
 
 function SetCoreGuiChatConnections(containerTable)
-	if not UserInputService.VREnabled then
-		local tries = 0
-		while tries < MAX_COREGUI_CONNECTION_ATTEMPTS do
-			tries = tries + 1
-			local success, ret = pcall(function() StarterGui:SetCore("CoreGuiChatConnections", containerTable) end)
-			if success then
-				break
-			end
-			if not success and tries == MAX_COREGUI_CONNECTION_ATTEMPTS then
-				error("Error calling SetCore CoreGuiChatConnections: " .. ret)
-			end
-			wait()
+	local tries = 0
+	while tries < MAX_COREGUI_CONNECTION_ATTEMPTS do
+		tries = tries + 1
+		local success, ret = pcall(function() StarterGui:SetCore("CoreGuiChatConnections", containerTable) end)
+		if success then
+			break
 		end
+		if not success and tries == MAX_COREGUI_CONNECTION_ATTEMPTS then
+			error("Error calling SetCore CoreGuiChatConnections: " .. ret)
+		end
+		wait()
 	end
 end
 

--- a/CoreScriptsRoot/Modules/Server/ClientChat/ChatScript.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/ChatScript.lua
@@ -125,7 +125,7 @@ function checkBothChatTypesDisabled()
 	return false
 end
 
-if not GuiService:IsTenFootInterface() then
+if (not GuiService:IsTenFootInterface()) or (not game:GetService('UserInputService').VREnabled) then
 	if not checkBothChatTypesDisabled() then
 		DoEverything()
 	else

--- a/CoreScriptsRoot/Modules/Server/ClientChat/ChatScript.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/ChatScript.lua
@@ -125,7 +125,7 @@ function checkBothChatTypesDisabled()
 	return false
 end
 
-if (not GuiService:IsTenFootInterface()) or (not game:GetService('UserInputService').VREnabled) then
+if (not GuiService:IsTenFootInterface()) and (not game:GetService('UserInputService').VREnabled) then
 	if not checkBothChatTypesDisabled() then
 		DoEverything()
 	else

--- a/CoreScriptsRoot/Modules/Server/ClientChat/ChatScript.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/ChatScript.lua
@@ -102,17 +102,19 @@ local function DoEverything()
 end
 
 function SetCoreGuiChatConnections(containerTable)
-	local tries = 0
-	while tries < MAX_COREGUI_CONNECTION_ATTEMPTS do
-		tries = tries + 1
-		local success, ret = pcall(function() StarterGui:SetCore("CoreGuiChatConnections", containerTable) end)
-		if success then
-			break
+	if not UserInputService.VREnabled then
+		local tries = 0
+		while tries < MAX_COREGUI_CONNECTION_ATTEMPTS do
+			tries = tries + 1
+			local success, ret = pcall(function() StarterGui:SetCore("CoreGuiChatConnections", containerTable) end)
+			if success then
+				break
+			end
+			if not success and tries == MAX_COREGUI_CONNECTION_ATTEMPTS then
+				error("Error calling SetCore CoreGuiChatConnections: " .. ret)
+			end
+			wait()
 		end
-		if not success and tries == MAX_COREGUI_CONNECTION_ATTEMPTS then
-			error("Error calling SetCore CoreGuiChatConnections: " .. ret)
-		end
-		wait()
 	end
 end
 


### PR DESCRIPTION
SetCore fails when in VR Mode. Another (fix) could be preventing DoEverything being called when in VR mode, but I am unsure if it is used in VR. 