### PR TITLE
Fix a leaderstats bug

### DIFF
--- a/CoreScriptsRoot/Modules/PlayerlistModule.lua
+++ b/CoreScriptsRoot/Modules/PlayerlistModule.lua
@@ -582,15 +582,19 @@ local function formatNumber(value)
 end
 
 local function formatStatString(text)
-  local numberValue = tonumber(text)
-  if numberValue then
-    text = formatNumber(numberValue)
-  end
+  if tostring(text) == "inf" then
+    local numberValue = tonumber(text)
+    if numberValue then
+      text = formatNumber(numberValue)
+    end
 
-  if strWidth(text) <= MAX_STR_LEN then
-    return text
+    if strWidth(text) <= MAX_STR_LEN then
+      return text
+    else
+      return string.sub(text, 1, MAX_STR_LEN - 3).."..."
+    end
   else
-    return string.sub(text, 1, MAX_STR_LEN - 3).."..."
+    return "∞"
   end
 end
 

--- a/CoreScriptsRoot/Modules/PlayerlistModule.lua
+++ b/CoreScriptsRoot/Modules/PlayerlistModule.lua
@@ -582,7 +582,7 @@ local function formatNumber(value)
 end
 
 local function formatStatString(text)
-  if tostring(text) == "inf" then
+  if tostring(text) ~= "inf" then
     local numberValue = tonumber(text)
     if numberValue then
       text = formatNumber(numberValue)


### PR DESCRIPTION
Attempting to set a StringValue leaderstat to math.huge will result in this error:

CoreGui.RobloxGui.Modules.PlayerlistModule:580: attempt to index local 'int' (a nil value)
Stack Begin
Script 'CoreGui.RobloxGui.Modules.PlayerlistModule', Line 580 - upvalue formatNumber
Script 'CoreGui.RobloxGui.Modules.PlayerlistModule', Line 587 - upvalue formatStatString
Script 'CoreGui.RobloxGui.Modules.PlayerlistModule', Line 998 - upvalue initializeStatText
Script 'CoreGui.RobloxGui.Modules.PlayerlistModule', Line 1055 - upvalue updateLeaderstatFrames
Script 'CoreGui.RobloxGui.Modules.PlayerlistModule', Line 1204 - upvalue onStatAdded
Script 'CoreGui.RobloxGui.Modules.PlayerlistModule', Line 1223
Stack End

This should fix it.
Feel free to change it around.