### PR TITLE
Change BubbleChat font from SourceSans to SourceSansBold

### DIFF
--- a/CoreScriptsRoot/Modules/Server/ClientChat/BubbleChat/BubbleChat.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/BubbleChat/BubbleChat.lua
@@ -20,7 +20,7 @@ end
 local PlayerGui = LocalPlayer:WaitForChild("PlayerGui")
 
 --[[ SCRIPT VARIABLES ]]
-local CHAT_BUBBLE_FONT = Enum.Font.SourceSans
+local CHAT_BUBBLE_FONT = Enum.Font.SourceSansBold -- changed because SourceSans cannot display certain unicode charachters correctly
 local CHAT_BUBBLE_FONT_SIZE = Enum.FontSize.Size24 -- if you change CHAT_BUBBLE_FONT_SIZE_INT please change this to match
 local CHAT_BUBBLE_FONT_SIZE_INT = 24 -- if you change CHAT_BUBBLE_FONT_SIZE please change this to match
 local CHAT_BUBBLE_LINE_HEIGHT = CHAT_BUBBLE_FONT_SIZE_INT + 10

--- a/CoreScriptsRoot/Modules/Server/ClientChat/BubbleChat/BubbleChat.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/BubbleChat/BubbleChat.lua
@@ -20,7 +20,7 @@ end
 local PlayerGui = LocalPlayer:WaitForChild("PlayerGui")
 
 --[[ SCRIPT VARIABLES ]]
-local CHAT_BUBBLE_FONT = Enum.Font.Arial -- changed because SourceSans cannot display certain unicode charachters correctly
+local CHAT_BUBBLE_FONT = Enum.Font.SourceSansBold -- changed because SourceSans cannot display certain unicode charachters correctly
 local CHAT_BUBBLE_FONT_SIZE = Enum.FontSize.Size24 -- if you change CHAT_BUBBLE_FONT_SIZE_INT please change this to match
 local CHAT_BUBBLE_FONT_SIZE_INT = 24 -- if you change CHAT_BUBBLE_FONT_SIZE please change this to match
 local CHAT_BUBBLE_LINE_HEIGHT = CHAT_BUBBLE_FONT_SIZE_INT + 10

--- a/CoreScriptsRoot/Modules/Server/ClientChat/BubbleChat/BubbleChat.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/BubbleChat/BubbleChat.lua
@@ -20,7 +20,7 @@ end
 local PlayerGui = LocalPlayer:WaitForChild("PlayerGui")
 
 --[[ SCRIPT VARIABLES ]]
-local CHAT_BUBBLE_FONT = Enum.Font.SourceSansBold -- changed because SourceSans cannot display certain unicode charachters correctly
+local CHAT_BUBBLE_FONT = Enum.Font.Arial -- changed because SourceSans cannot display certain unicode charachters correctly
 local CHAT_BUBBLE_FONT_SIZE = Enum.FontSize.Size24 -- if you change CHAT_BUBBLE_FONT_SIZE_INT please change this to match
 local CHAT_BUBBLE_FONT_SIZE_INT = 24 -- if you change CHAT_BUBBLE_FONT_SIZE please change this to match
 local CHAT_BUBBLE_LINE_HEIGHT = CHAT_BUBBLE_FONT_SIZE_INT + 10


### PR DESCRIPTION
Solves issue #998 

SourceSans cannot correctly display Non-English Unicode Characters, and instead replaces them with � (SourceSans displays � as a box with a X through it). SourceSansBold, however, can display Non-English Unicode Characters. Arial can also do so, so if SourceSansBold is considered ugly or out-of-place, Arial can be used to replace it.

I suggest reverting this change (or keeping it, because SourceSansBold looks pretty nice) once ROBLOX fixes the font to work with unicode.

Want to see how it would look? Vist [my testing ground](https://www.roblox.com/games/929781001/github-issue-998-pull-link) to view how this would look.

*p.s*
![picture of sourcesansbold being used in-game](https://user-images.githubusercontent.com/28220558/28474970-93fcd5f2-6e18-11e7-87a3-6fb503464f79.png)
