### PR TITLE
Added support for toggling stats huds on mobile.

### DIFF
--- a/CoreScriptsRoot/Modules/NewChat.lua
+++ b/CoreScriptsRoot/Modules/NewChat.lua
@@ -288,7 +288,12 @@ do
 		end
 
 		StarterGui:RegisterSetCore("CoreGuiChatConnections", RegisterCoreGuiConnections)
-
+	
+		-- Register ShowStatsBasedOnInputString for the /togglestats commands
+		StarterGui:RegisterSetCore("ShowStatsBasedOnInputString",function (statName)
+			assert(typeof(statName) == "string","ShowStatsBasedOnInputString expects a string to be passed.")
+			GuiService:ShowStatsBasedOnInputString(statName)
+		end)
 end
 
 return moduleApiTable

--- a/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/CommandModules/EngineStats.lua
+++ b/CoreScriptsRoot/Modules/Server/ClientChat/DefaultClientChatModules/CommandModules/EngineStats.lua
@@ -1,0 +1,42 @@
+--	// FileName: EngineStats.lua
+--	// Written by: CloneTrooper1019
+--	// Description: Command to toggle engine stats.
+
+local StarterGui = game:GetService("StarterGui")
+local util = require(script.Parent:WaitForChild("Util"))
+
+local statsMap =
+{
+	general = "Genstats";
+	rendering = "Renstats";
+	network = "Netstats";
+	physics = "Phystats";
+	summary = "Sumstats";
+	custom = "Cusstats";
+	conhealth = "ConnectionHealth";
+}
+
+function ProcessMessage(message, ChatWindow, ChatSettings)
+	if string.sub(message, 1, 12):lower() == "/togglestats" then
+		local currentChannel = ChatWindow:GetCurrentChannel()
+		local stat = string.sub(message,14):lower()
+		if stat == "" then
+			stat = "general"
+		end
+		if statsMap[stat] then
+			local success = pcall(function () StarterGui:SetCore("ShowStatsBasedOnInputString",statsMap[stat]) end)
+			if not success then
+				util:SendSystemMessageToSelf("/togglestats is currently not available.",currentChannel,{})
+			end
+		else
+			util:SendSystemMessageToSelf(string.format("%q is not a valid /togglestats category",stat),currentChannel,{})
+		end
+		return true
+	end
+	return false
+end
+
+return {
+	[util.KEY_COMMAND_PROCESSOR_TYPE] = util.COMPLETED_MESSAGE_PROCESSOR,
+	[util.KEY_PROCESSOR_FUNCTION] = ProcessMessage
+}


### PR DESCRIPTION
This commit adds a SetCore method called ShowStatsBasedOnInputString,
which calls the GuIService method of the same name. It also adds a new
client chat command called /togglestats, which works with the following:

/togglestats (Toggles the General stats hud)
/togglestats general (Toggles the General stats hud)
/togglestats rendering (Toggles the Rendering stats hud)
/togglestats network (Toggles the Network stats hud)
/togglestats physics (Toggles the Physics stats hud)
/togglestats summary (Toggles the Summary stats hud)
/togglestats custom (Toggles the Custom stats hud)
/togglestats conhealth (Toggles the Connection Health stats hud)