### PR TITLE
Fix character not being ignored in first person with invisicam enabled

### DIFF
--- a/PlayerScripts/StarterPlayerScripts/CameraScript/Invisicam.lua
+++ b/PlayerScripts/StarterPlayerScripts/CameraScript/Invisicam.lua
@@ -489,7 +489,7 @@ function Invisicam:Update()
 	-- rays coming from the camera would not be considered as hitting the part. This code adds all parts
 	-- that touch a 2x2x2 box around the camera position.
 	local region3 = Region3.new(Camera.CFrame.p + Vector3_new(-1,-1,-1), Camera.CFrame.p + Vector3_new(1,1,1))
-	local partsTouchingCamera = game.Workspace:FindPartsInRegion3(region3,nil,10)	
+	local partsTouchingCamera = game.Workspace:FindPartsInRegion3(region3,Character,10)	
 	for _,part in pairs(partsTouchingCamera) do
 		hitParts[#hitParts+1] = part
 		partIsTouchingCamera[part] = true


### PR DESCRIPTION
Character is not ignored in first person with invisicam enabled causing an issue where in first person you can see your character's body as invisicam glitches out with the the TransparencyController not updating every frame.

This only happens when running or when the character is moved a bit from the camera origin. 

This is clearly a bug. This one change can fix that. 