### PR TITLE
Add call to getCustomPlayerIcon function in blockStatusChanged

### DIFF
--- a/CoreScriptsRoot/Modules/PlayerlistModule.lua
+++ b/CoreScriptsRoot/Modules/PlayerlistModule.lua
@@ -1786,12 +1786,14 @@ local blockStatusChanged = function(userId, isBlocked)
 
   for _,playerEntry in ipairs(PlayerEntries) do
     if playerEntry.Player.UserId == userId then
-      playerEntry.Frame.BGFrame.MembershipIcon.Image = getMembershipIcon(playerEntry.Player)
+      local membershipIcon  = getMembershipIcon(playerEntry.Player)
+      local iconImage       = getCustomPlayerIcon(playerEntry.Player)
+
+      playerEntry.Frame.BGFrame.MembershipIcon.Image = iconImage ~= nil and iconImage or membershipIcon
       return
     end
   end
 end
-
 blockingUtility:GetBlockedStatusChangedEvent():connect(blockStatusChanged)
 
 return Playerlist


### PR DESCRIPTION
See issue https://github.com/Roblox/Core-Scripts/issues/1016 for more information

(tl;dr admin icons not shown after unblock, fixes this behaviour)

I'd like to point out that, due to the nature of this issue, testing has been limited because I have no access to CoreScript functions.
