### PR TITLE
Add "ReportPlayer" SetCore functionality

### DIFF
--- a/CoreScriptsRoot/CoreScripts/ReportPlayer.lua
+++ b/CoreScriptsRoot/CoreScripts/ReportPlayer.lua
@@ -1,0 +1,51 @@
+--[[
+		Filename: ReportPlayer.lua
+		Written by: boynedmaster/Kampfkarren
+		Version 1.0
+		Description: Adds ReportPlayer SetCore function.
+        Notes:       This basically just acts as a wrapper for Players:ReportAbuse, but in a context level normal LocalScripts can access.
+                     It is a separate file rather than inside a similar script, such as ReportAbuseMenu.lua, to ensure the SetCore functionality exists on startup.
+                     Why you would want to use it on startup I have no clue, but TheGamer101 said on the developer forum
+                     "Currently we try to make all SetCore and GetCore methods work without requiring the developer to wait a frame before calling it."
+--]]
+
+local PlayersService = game:GetService("Players")
+local StarterGui = game:GetService("StarterGui")
+
+StarterGui:RegisterSetCore("ReportPlayer", function(arguments)
+    if typeof(arguments) ~= "table" then
+        warn("ReportPlayer expects a table of arguments.")
+        return
+    end
+
+    if #arguments ~= 2 and #arguments ~= 3 then
+        warn("ReportPlayer expects 2-3 arguments.")
+        return
+    end
+    
+    local player = arguments[1]
+    local reason = arguments[2]
+    local optionalMessage = arguments[3] or ""
+
+    if typeof(player) ~= "Instance" or not player:IsA("Player") then
+        warn("Invalid argument 1 for ReportPlayer. Expected a Player.")
+        return
+    end
+
+    if typeof(reason) ~= "string" then
+        warn("Invalid argument 2 for ReportPlayer. Expected a string.")
+        return
+    end
+    
+    if typeof(optionalMessage) ~= "string" then
+        warn("Invalid argument 3 for ReportPlayer. Expected a string.")
+        return
+    end
+
+    if player == PlayersService.LocalPlayer then
+        warn("ReportPlayer tried to report the LocalPlayer.")
+        return
+    end
+
+    PlayersService:ReportAbuse(player, reason, optionalMessage)
+end)

--- a/CoreScriptsRoot/StarterScript.lua
+++ b/CoreScriptsRoot/StarterScript.lua
@@ -45,6 +45,9 @@ scriptContext:AddCoreScriptLocal("CoreScripts/PurchasePromptScript2", RobloxGui)
 scriptContext:AddCoreScriptLocal("CoreScripts/BlockPlayerPrompt", RobloxGui)
 scriptContext:AddCoreScriptLocal("CoreScripts/FriendPlayerPrompt", RobloxGui)
 
+-- ReportPlayer SetCore functionality
+scriptContext:AddCoreScriptLocal("CoreScripts/ReportPlayer", script.Parent)
+
 -- Backpack!
 spawn(function() safeRequire(RobloxGui.Modules.BackpackScript) end)
 


### PR DESCRIPTION
Right now, game developers can only tell players to report bad users through a few means. The first is by reporting the player through the settings hub (Escape menu). This can be a problem with games with servers of many players, where it is difficult to scroll through every single name until you find the player you want to report. The second is by clicking on the player's name in the player list and clicking Report Abuse. Not only does this have the same problems of scrolling through to find the user's name, a lot of games disable this list. The last method is by going to the Roblox website to report them, which is inconvenient for a player to have to go through.

This PR has a solution for the problem of inconvenient reporting methods. By letting a developer report a player through SetCore, they can add a button to their own player lists, next to parties from users, and more. Developers who abuse this feature will have punitive actions taken against them similar to those who abuse the MessagePosted chat connection.

# API

StarterGui:SetCore("ReportPlayer", table<Player, string, Ref<string>> configTable)

configTable has the format of {Player playerToReport, string reportReason, Ref<string> optionalMessage}.