### PR TITLE
fix for deprecated PromptProductPurchaseFinished event and #1006

### DIFF
--- a/CoreScriptsRoot/CoreScripts/PurchasePromptScript2.lua
+++ b/CoreScriptsRoot/CoreScripts/PurchasePromptScript2.lua
@@ -978,7 +978,7 @@ local function onPromptEnded(isSuccess)
 
 	closePurchaseDialog()
 	if IsPurchasingConsumable then
-		MarketplaceService:SignalPromptProductPurchaseFinished(Players.LocalPlayer.UserId, PurchaseData.ProductId, didPurchase)
+		MarketplaceService:SignalPromptPurchaseFinished(Players.LocalPlayer.UserId, PurchaseData.ProductId, didPurchase)
 	elseif IsPurchasingGamePass then
 		MarketplaceService:SignalPromptGamePassPurchaseFinished(Players.LocalPlayer, PurchaseData.GamePassId, didPurchase)
 	else


### PR DESCRIPTION
extension of #1006 but fixing incorrect 2nd parameter, passing `PurchaseData.ProductId` instead of `PurchaseData.AssetId`

Deprecated event documentation can be found [here](http://wiki.roblox.com/index.php?title=API:Class/MarketplaceService/PromptProductPurchaseFinished)
