### PR TITLE
Fix used services to conform to style guide

### DIFF
--- a/PlayerScripts/StarterCharacterScripts/Sound/LocalSound.client.lua
+++ b/PlayerScripts/StarterCharacterScripts/Sound/LocalSound.client.lua
@@ -9,6 +9,10 @@
 	This script is optimized to reduce network traffic through minimizing the amount of property replication.
 ]]--
 
+--Roblox Services
+local Workspace=game:GetService("Workspace")
+local Players=game:GetService("Players")
+
 --All sounds are referenced by this ID
 local SFX = {
 	Died = 0;
@@ -61,8 +65,8 @@ if useSoundDispatcher then
 	AddCharacterLoadedEvent:FireServer()
 
 	-- Notify the sound dispatcher this character has left.
-	game.Players.LocalPlayer.CharacterRemoving:connect(function(character)
-		RemoveCharacterEvent:FireServer(game.Players.LocalPlayer)
+	Players.LocalPlayer.CharacterRemoving:connect(function(character)
+		RemoveCharacterEvent:FireServer(Players.LocalPlayer)
 	end)
 end
 
@@ -109,7 +113,7 @@ do
 end
 
 local IsSoundFilteringEnabled = function()
-	return game.Workspace.FilteringEnabled and SoundService.RespectFilteringEnabled
+	return Workspace.FilteringEnabled and SoundService.RespectFilteringEnabled
 end
 
 local Util

--- a/PlayerScripts/StarterCharacterScripts/Sound/LocalSound.client.lua
+++ b/PlayerScripts/StarterCharacterScripts/Sound/LocalSound.client.lua
@@ -10,8 +10,8 @@
 ]]--
 
 --Roblox Services
-local Workspace=game:GetService("Workspace")
-local Players=game:GetService("Players")
+local Workspace = game:GetService("Workspace")
+local Players = game:GetService("Players")
 
 --All sounds are referenced by this ID
 local SFX = {

--- a/PlayerScripts/StarterCharacterScripts/Sound/LocalSound.client.lua
+++ b/PlayerScripts/StarterCharacterScripts/Sound/LocalSound.client.lua
@@ -10,8 +10,9 @@
 ]]--
 
 --Roblox Services
-local Workspace = game:GetService("Workspace")
 local Players = game:GetService("Players")
+local Workspace = game:GetService("Workspace")
+
 
 --All sounds are referenced by this ID
 local SFX = {


### PR DESCRIPTION
I fixed the various instances of `game.<ServiceName>` to use `game:GetService()`, conforming to the [Roblox style guide](https://roblox.github.io/lua-style-guide/).